### PR TITLE
Update with examples from HTTP Message Signatures draft 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,29 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.1.3, 2.12.15, 2.13.8]
+        scala: [3.1.3, 2.12.17, 2.13.8]
         java: [temurin@17, temurin@11]
+        project: [rootJS, rootJVM]
+        jsenv: [NodeJS, Chrome, Firefox]
         exclude:
           - scala: 3.1.3
             java: temurin@11
-          - scala: 2.12.15
+          - scala: 2.12.17
             java: temurin@11
+          - project: rootJS
+            java: temurin@11
+          - scala: 3.1.3
+            jsenv: Chrome
+          - scala: 3.1.3
+            jsenv: Firefox
+          - scala: 2.12.17
+            jsenv: Chrome
+          - scala: 2.12.17
+            jsenv: Firefox
+          - project: rootJVM
+            jsenv: Chrome
+          - project: rootJVM
+            jsenv: Firefox
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -81,43 +97,47 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Setup NodeJS v14 LTS
-        if: matrix.ci == 'ciJS'
-        uses: actions/setup-node@v2.4.0
+      - name: Setup NodeJS v16 LTS
+        if: matrix.project == 'rootJS' && matrix.jsenv == 'NodeJS'
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Check that workflows are up to date
-        run: sbt '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
+        run: 'sbt ''project ${{ matrix.project }}'' ''++${{ matrix.scala }}'' ''set Global / useJSEnv := JSEnv.${{ matrix.jsenv }}'' ''project /'' githubWorkflowCheck'
 
       - name: Check headers and formatting
         if: matrix.java == 'temurin@17'
-        run: sbt '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
+        run: 'sbt ''project ${{ matrix.project }}'' ''++${{ matrix.scala }}'' ''set Global / useJSEnv := JSEnv.${{ matrix.jsenv }}'' headerCheckAll scalafmtCheckAll ''project /'' scalafmtSbtCheck'
+
+      - name: scalaJSLink
+        if: matrix.project == 'rootJS'
+        run: 'sbt ''project ${{ matrix.project }}'' ''++${{ matrix.scala }}'' ''set Global / useJSEnv := JSEnv.${{ matrix.jsenv }}'' Test/scalaJSLinkerResult'
 
       - name: Test
-        run: sbt '++${{ matrix.scala }}' test
+        run: 'sbt ''project ${{ matrix.project }}'' ''++${{ matrix.scala }}'' ''set Global / useJSEnv := JSEnv.${{ matrix.jsenv }}'' test'
 
       - name: Check binary compatibility
         if: matrix.java == 'temurin@17'
-        run: sbt '++${{ matrix.scala }}' mimaReportBinaryIssues
+        run: 'sbt ''project ${{ matrix.project }}'' ''++${{ matrix.scala }}'' ''set Global / useJSEnv := JSEnv.${{ matrix.jsenv }}'' mimaReportBinaryIssues'
 
       - name: Generate API documentation
         if: matrix.java == 'temurin@17'
-        run: sbt '++${{ matrix.scala }}' doc
+        run: 'sbt ''project ${{ matrix.project }}'' ''++${{ matrix.scala }}'' ''set Global / useJSEnv := JSEnv.${{ matrix.jsenv }}'' doc'
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p target rootJS/target core/js/target core/jvm/target rootJVM/target test-runtime/.jvm/target test-runtime/.js/target project/target
+        run: mkdir -p target .js/target core/js/target core/jvm/target .jvm/target .native/target test-runtime/.jvm/target test-runtime/.js/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar target rootJS/target core/js/target core/jvm/target rootJVM/target test-runtime/.jvm/target test-runtime/.js/target project/target
+        run: tar cf targets.tar target .js/target core/js/target core/jvm/target .jvm/target .native/target test-runtime/.jvm/target test-runtime/.js/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
+          name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.jsenv }}-${{ matrix.project }}
           path: targets.tar
 
   publish:
@@ -180,32 +200,62 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (3.1.3)
+      - name: Download target directories (3.1.3, NodeJS, rootJS)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3-NodeJS-rootJS
 
-      - name: Inflate target directories (3.1.3)
+      - name: Inflate target directories (3.1.3, NodeJS, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12.15)
+      - name: Download target directories (3.1.3, NodeJS, rootJVM)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3-NodeJS-rootJVM
 
-      - name: Inflate target directories (2.12.15)
+      - name: Inflate target directories (3.1.3, NodeJS, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.8)
+      - name: Download target directories (2.12.17, NodeJS, rootJS)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-NodeJS-rootJS
 
-      - name: Inflate target directories (2.13.8)
+      - name: Inflate target directories (2.12.17, NodeJS, rootJS)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (2.12.17, NodeJS, rootJVM)
+        uses: actions/download-artifact@v3
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-NodeJS-rootJVM
+
+      - name: Inflate target directories (2.12.17, NodeJS, rootJVM)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (2.13.8, NodeJS, rootJS)
+        uses: actions/download-artifact@v3
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-NodeJS-rootJS
+
+      - name: Inflate target directories (2.13.8, NodeJS, rootJS)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (2.13.8, NodeJS, rootJVM)
+        uses: actions/download-artifact@v3
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-NodeJS-rootJVM
+
+      - name: Inflate target directories (2.13.8, NodeJS, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/README.md
+++ b/README.md
@@ -13,19 +13,24 @@ where hash is one of the hashes published in the sonatype [net.bblfish.crypto](h
                          
 ## Symmetric Keys
 
-bobcats has implementation for symmetric keys on all three platforms (Java, Browser JS and Node JS)
+bobcats has an implementation for symmetric keys on all three platforms (Java, Browser JS and Node JS)
 and implementation of asymetric keys for Java and Browser JS needed for "Signing HTTP Messages"
 examples. 
 It is being used by [httpSig](https://github.com/bblfish/httpSig).
 
 ## Asymmetric Keys
 
-bobcats has implementions for asymmetric keys on Java and BrowserJS. To get NodeJS working we would need to select an implementation of the JS Crypto API for Node, or write code specifically using the Node Crypto libraries.
+bobcats has an implementions for asymmetric keys on Java and BrowserJS. To get NodeJS working we would need to select an implementation of the JS Crypto API for Node, or write code specifically using the Node Crypto libraries.
 
-To test those one needs to implement the Browser drivers.
 
 ## Todo
 
 - clean up the API a lot, especially improve algorithm names
 - add more tests
 - add more cryptographic suites
+
+# Howto
+
+## Running browser tests locally
+
+To test the browser JS you need to install [the Selenium drivers](https://www.selenium.dev/downloads/) for your Operating Systems and have the corresponding browsers installed too.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ libraryDependencies += "net.bblfish.crypto" %% "bobcats" % "0.2-${hash}-SNAPSHOT
 where hash is one of the hashes published in the sonatype [net.bblfish.crypto](https://oss.sonatype.org/content/repositories/snapshots/net/bblfish/crypto/) snapshot repo.
 
 ## Current state
+                         
+## Symmetric Keys
 
 bobcats has implementation for symmetric keys on all three platforms (Java, Browser JS and Node JS)
 and implementation of asymetric keys for Java and Browser JS needed for "Signing HTTP Messages"
 examples. 
 It is being used by [httpSig](https://github.com/bblfish/httpSig).
+
+## Asymmetric Keys
+
+bobcats has implementions for asymmetric keys on Java and BrowserJS. To get NodeJS working we would need to select an implementation of the JS Crypto API for Node, or write code specifically using the Node Crypto libraries.
+
+To test those one needs to implement the Browser drivers.
 
 ## Todo
 

--- a/build.sbt
+++ b/build.sbt
@@ -38,9 +38,6 @@ ThisBuild / startYear := Some(2021)
 enablePlugins(TypelevelCiReleasePlugin)
 enablePlugins(TypelevelSonatypePlugin)
 
-ThisBuild / tlCiReleaseBranches := Seq("main")
-// ThisBuild / tlSonatypeUseLegacyHost := false // TODO remove
-
 ThisBuild / crossScalaVersions := Seq("3.1.3", "2.12.17", "2.13.8")
 
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -57,23 +57,8 @@ ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"), JavaSpec.t
 
 lazy val useJSEnv =
   settingKey[JSEnv]("Use Node.js or a headless browser for running Scala.js tests")
+  
 Global / useJSEnv := NodeJS
-
-ThisBuild / Test / jsEnv := {
-  val old = (Test / jsEnv).value
-
-  useJSEnv.value match {
-    case NodeJS => old
-    case Firefox =>
-      val options = new FirefoxOptions()
-      options.setHeadless(true)
-      new SeleniumJSEnv(options)
-    case Chrome =>
-      val options = new ChromeOptions()
-      options.setHeadless(true)
-      new SeleniumJSEnv(options)
-  }
-}
 
 ThisBuild / Test / jsEnv := {
   val old = (Test / jsEnv).value
@@ -99,7 +84,7 @@ val munitCEVersion = "1.0.7"
 val disciplineMUnitVersion = "1.0.9"
 val bouncyVersion = "1.72"
 val domVersion = "2.3.0"
-val nimbusJWTVersion = "9.25.4"
+val nimbusJWTVersion = "9.25.6"
 
 lazy val root =
   project.in(file(".")).aggregate(rootJS, rootJVM).enablePlugins(NoPublishPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"), JavaSpec.t
 
 lazy val useJSEnv =
   settingKey[JSEnv]("Use Node.js or a headless browser for running Scala.js tests")
-  
+
 Global / useJSEnv := NodeJS
 
 ThisBuild / Test / jsEnv := {

--- a/core/js/src/main/scala/bobcats/KeyPlatform.scala
+++ b/core/js/src/main/scala/bobcats/KeyPlatform.scala
@@ -42,6 +42,7 @@ private[bobcats] trait PrivateKeyPlatform {
 private[bobcats] trait SecretKeyPlatform
 
 private[bobcats] trait SecretKeySpecPlatform[+A <: Algorithm]
+
 private[bobcats] trait PKCS8KeySpecPlatform[+A <: AsymmetricKeyAlg] extends PrivateKeyPlatform {
   self: PKCS8KeySpec[A] =>
   // A JS Web Crypto Key combines the public key and signature algorithms, unlike Java
@@ -54,12 +55,16 @@ private[bobcats] trait PKCS8KeySpecPlatform[+A <: AsymmetricKeyAlg] extends Priv
         key.toJSArrayBuffer,
         JSKeySpec.importAlgorithm(algorithm, signature),
         true,
-        js.Array(dom.KeyUsage.sign)
+        js.Array(
+          dom.KeyUsage.sign
+        ) // private keys sign (and cna also encrypt) -- todo how to set encryption?
       )
     })
 }
+
 private[bobcats] trait SPKIKeySpecPlatform[+A <: AsymmetricKeyAlg] {
   self: SPKIKeySpec[A] =>
+
   def toWebCryptoKey[F[_]](signature: AsymmetricKeyAlg.Signature)(
       implicit F0: Async[F]
   ): F[org.scalajs.dom.CryptoKey] =
@@ -69,7 +74,7 @@ private[bobcats] trait SPKIKeySpecPlatform[+A <: AsymmetricKeyAlg] {
         key.toJSArrayBuffer,
         JSKeySpec.importAlgorithm(algorithm, signature),
         true, // todo: do we always want extractable?
-        js.Array(dom.KeyUsage.verify) // todo: we may want other key usages?
+        js.Array(dom.KeyUsage.verify) // public keys (SPKI) verify
       )
     })
 }

--- a/core/js/src/test/scala/bobcats/JSBasicSignerSuite.scala
+++ b/core/js/src/test/scala/bobcats/JSBasicSignerSuite.scala
@@ -33,6 +33,7 @@
 package bobcats
 
 import bobcats.util.WebCryptoPEMUtils
+import cats.effect.IO
 import munit.CatsEffectSuite
 
 import scala.util.Success
@@ -40,6 +41,7 @@ import scala.util.Success
 //todo: thos test only makes sense for Java at present as BouncyCastle actually
 // parses the content. Move to Java.
 class JSBasicSignerSuite extends CatsEffectSuite {
+  implicit val signer: Signer[IO] = Signer.forAsync[IO]
 
   test("parse `test-key-rsa`") {
 //		assertIO(IO(4),4)

--- a/core/js/src/test/scala/bobcats/JSBasicSignerSuite.scala
+++ b/core/js/src/test/scala/bobcats/JSBasicSignerSuite.scala
@@ -46,7 +46,7 @@ class JSBasicSignerSuite extends CatsEffectSuite {
     assertEquals(
       WebCryptoPEMUtils
         .getPrivateKeySpec(
-          bobcats.SigningHttpMessages.`test-key-rsa`.privatePk8Key,
+          bobcats.HttpMessageSignaturesV07.`test-key-rsa`.privatePk8Key,
           bobcats.AsymmetricKeyAlg.RSA_PKCS_Key
         )
         .map(pk => pk.algorithm),
@@ -58,7 +58,7 @@ class JSBasicSignerSuite extends CatsEffectSuite {
     assertEquals(
       WebCryptoPEMUtils
         .getPrivateKeySpec(
-          bobcats.SigningHttpMessages.`test-key-rsa-pss`.privatePk8Key,
+          bobcats.HttpMessageSignaturesV07.`test-key-rsa-pss`.privatePk8Key,
           AsymmetricKeyAlg.RSA_PSS_Key
         )
         .map(pk => pk.algorithm),
@@ -70,7 +70,7 @@ class JSBasicSignerSuite extends CatsEffectSuite {
     assertEquals(
       WebCryptoPEMUtils
         .getPrivateKeySpec(
-          bobcats.SigningHttpMessages.`test-key-ecc-p256`.privatePk8Key,
+          bobcats.HttpMessageSignaturesV07.`test-key-ecc-p256`.privatePk8Key,
           AsymmetricKeyAlg.ECKey(bobcats.AsymmetricKeyAlg.`P-256`)
         )
         .map(pk => pk.algorithm),

--- a/core/js/src/test/scala/bobcats/JSSignerSuite.scala
+++ b/core/js/src/test/scala/bobcats/JSSignerSuite.scala
@@ -35,7 +35,7 @@ package bobcats
 import bobcats.HttpMessageSignaturesV07.`Github-Issue-1509-Example`
 import bobcats.util.{PEMUtils, WebCryptoPEMUtils}
 import cats.effect.IO
-import cats.effect.kernel.Async
+import cats.effect.kernel.{Async, Sync}
 
 class JSSignerSuite07 extends SignerSuite {
   override implicit val pemutils: PEMUtils = WebCryptoPEMUtils
@@ -44,6 +44,7 @@ class JSSignerSuite07 extends SignerSuite {
 
   implicit val signer: Signer[IO] = Signer.forAsync[IO]
   implicit val verifier: Verifier[IO] = Verifier.forAsync[IO]
+  implicit val s: Sync[IO] = Async[IO]
 
   if (!BuildInfo.runtime.contains("NodeJS")) {
     run[IO](HttpMessageSignaturesV07.sigExamples.filterNot(_ == `Github-Issue-1509-Example`))
@@ -59,6 +60,7 @@ class JSSignerSuite13 extends SignerSuite {
 
   implicit val signer: Signer[IO] = Signer.forAsync[IO]
   implicit val verifier: Verifier[IO] = Verifier.forAsync[IO]
+  implicit val s: Sync[IO] = Async[IO]
 
   if (!BuildInfo.runtime.contains("NodeJS")) {
     run[IO](HttpMessageSignaturesV13.sigExamples.filterNot(_ == `Github-Issue-1509-Example`))

--- a/core/js/src/test/scala/bobcats/JSSignerSuite.scala
+++ b/core/js/src/test/scala/bobcats/JSSignerSuite.scala
@@ -49,7 +49,7 @@ class JSSignerSuite07 extends SignerSuite {
     run[IO](HttpMessageSignaturesV07.sigExamples.filterNot(_ == `Github-Issue-1509-Example`))
   }
   // we have not implemented crypto for NodeJS yet
-    
+
 }
 
 class JSSignerSuite13 extends SignerSuite {

--- a/core/js/src/test/scala/bobcats/JSSignerSuite.scala
+++ b/core/js/src/test/scala/bobcats/JSSignerSuite.scala
@@ -32,12 +32,12 @@ package bobcats
  * limitations under the License.
  */
 
-import bobcats.SigningHttpMessages.`Github-Issue-1509-Example`
+import bobcats.HttpMessageSignaturesV07.`Github-Issue-1509-Example`
 import bobcats.util.{PEMUtils, WebCryptoPEMUtils}
 import cats.effect.IO
 import cats.effect.kernel.Async
 
-class JSSignerSuite extends SignerSuite {
+class JSSignerSuite07 extends SignerSuite {
   override implicit val pemutils: PEMUtils = WebCryptoPEMUtils
 
   implicit val synio: Async[IO] = IO.asyncForIO
@@ -45,7 +45,24 @@ class JSSignerSuite extends SignerSuite {
   implicit val signer: Signer[IO] = Signer.forAsync[IO]
   implicit val verifier: Verifier[IO] = Verifier.forAsync[IO]
 
-  if (!BuildInfo.runtime.contains("NodeJS"))
-    run[IO](SigningHttpMessages.signatureExamples.filterNot(_ == `Github-Issue-1509-Example`))
+  if (!BuildInfo.runtime.contains("NodeJS")) {
+    run[IO](HttpMessageSignaturesV07.sigExamples.filterNot(_ == `Github-Issue-1509-Example`))
+  }
+  // we have not implemented crypto for NodeJS yet
+    
+}
 
+class JSSignerSuite13 extends SignerSuite {
+  override implicit val pemutils: PEMUtils = WebCryptoPEMUtils
+
+  implicit val synio: Async[IO] = IO.asyncForIO
+
+  implicit val signer: Signer[IO] = Signer.forAsync[IO]
+  implicit val verifier: Verifier[IO] = Verifier.forAsync[IO]
+
+  if (!BuildInfo.runtime.contains("NodeJS")) {
+    run[IO](HttpMessageSignaturesV13.sigExamples.filterNot(_ == `Github-Issue-1509-Example`))
+//    runSym[IO](HttpMessageSignaturesV13.symSignExamples)
+  }
+  // we have not implemented crypto for NodeJS yet
 }

--- a/core/js/src/test/scala/bobcats/JSSignerSuite.scala
+++ b/core/js/src/test/scala/bobcats/JSSignerSuite.scala
@@ -32,7 +32,6 @@ package bobcats
  * limitations under the License.
  */
 
-import bobcats.HttpMessageSignaturesV07.`Github-Issue-1509-Example`
 import bobcats.util.{PEMUtils, WebCryptoPEMUtils}
 import cats.effect.IO
 import cats.effect.kernel.{Async, Sync}
@@ -47,7 +46,15 @@ class JSSignerSuite07 extends SignerSuite {
   implicit val s: Sync[IO] = Async[IO]
 
   if (!BuildInfo.runtime.contains("NodeJS")) {
-    run[IO](HttpMessageSignaturesV07.sigExamples.filterNot(_ == `Github-Issue-1509-Example`))
+    // this could be perhaps done with `munit.Tag`s . Also it would be nice to
+    // have this be in a warning color.
+    val okForWebCryptAPI = HttpMessageSignaturesV07.sigExamples.groupBy { sigEx =>
+      sigEx.notFor().collectFirst { case _: NoWebCryptAPI => false }.getOrElse(true)
+    }
+    for (sigEx <- okForWebCryptAPI(false)) {
+      test(s"cannot run test ${sigEx.description} because of ${sigEx.notFor()}") {}
+    }
+    run[IO](okForWebCryptAPI(true))
   }
   // we have not implemented crypto for NodeJS yet
 
@@ -60,11 +67,20 @@ class JSSignerSuite13 extends SignerSuite {
 
   implicit val signer: Signer[IO] = Signer.forAsync[IO]
   implicit val verifier: Verifier[IO] = Verifier.forAsync[IO]
+  implicit val hmac: Hmac[IO] = Hmac.forAsyncOrSync[IO]
   implicit val s: Sync[IO] = Async[IO]
 
   if (!BuildInfo.runtime.contains("NodeJS")) {
-    run[IO](HttpMessageSignaturesV13.sigExamples.filterNot(_ == `Github-Issue-1509-Example`))
-//    runSym[IO](HttpMessageSignaturesV13.symSignExamples)
+    // this could be perhaps done with `munit.Tag`s . Also it would be nice to
+    // have this be in a warning color.
+    val okForWebCryptAPI = HttpMessageSignaturesV07.sigExamples.groupBy { sigEx =>
+      sigEx.notFor().collectFirst { case _: NoWebCryptAPI => false }.getOrElse(true)
+    }
+    for (sigEx <- okForWebCryptAPI(false)) {
+      test(s"cannot run test ${sigEx.description} because of ${sigEx.notFor()}") {}
+    }
+    run[IO](okForWebCryptAPI(true))
+    runSym[IO](HttpMessageSignaturesV13.symSignExamples)
   }
   // we have not implemented crypto for NodeJS yet
 }

--- a/core/jvm/src/test/scala/bobcats/JWKCryptoSuite.scala
+++ b/core/jvm/src/test/scala/bobcats/JWKCryptoSuite.scala
@@ -24,14 +24,14 @@ class JWKCryptoSuite extends munit.FunSuite {
 
   test("transform PEM private to JWK") {
     val jwk = JWK.parseFromPEMEncodedObjects(
-      SigningHttpMessages.`test-key-rsa-pss`.privateKey
+      HttpMessageSignaturesV07.`test-key-rsa-pss`.privateKey
     )
     assertEquals(jwk.getKeyType.toString, "RSA")
   }
 
   test("transform PEM public to JWK") {
     val jwk = JWK.parseFromPEMEncodedObjects(
-      SigningHttpMessages.`test-key-rsa-pss`.publicKey
+      HttpMessageSignaturesV13.`test-key-rsa-pss`.publicKey
     )
     assertEquals(jwk.getKeyType.toString, "RSA")
 

--- a/core/jvm/src/test/scala/bobcats/JavaSignerSuite07.scala
+++ b/core/jvm/src/test/scala/bobcats/JavaSignerSuite07.scala
@@ -19,7 +19,7 @@ package bobcats
 import bobcats.util.{BouncyJavaPEMUtils, PEMUtils}
 import cats.effect.{MonadCancel, Sync, SyncIO}
 
-class JavaSignerSuite extends SignerSuite {
+class JavaSignerSuite07 extends SignerSuite {
 
   override def pemutils: PEMUtils = BouncyJavaPEMUtils
 
@@ -27,5 +27,17 @@ class JavaSignerSuite extends SignerSuite {
   implicit val signer: Signer[SyncIO] = Signer.forSync[SyncIO]
   implicit val verifier: Verifier[SyncIO] = Verifier.forSync[SyncIO]
 
-  run[SyncIO](SigningHttpMessages.signatureExamples)
+  run[SyncIO](HttpMessageSignaturesV07.sigExamples)
+}
+
+class JavaSignerSuiteV13 extends SignerSuite {
+
+  override def pemutils: PEMUtils = BouncyJavaPEMUtils
+
+  implicit val synio: Sync[SyncIO] with MonadCancel[SyncIO, Throwable] = SyncIO.syncForSyncIO
+  implicit val signer: Signer[SyncIO] = Signer.forSync[SyncIO]
+  implicit val verifier: Verifier[SyncIO] = Verifier.forSync[SyncIO]
+
+  run[SyncIO](HttpMessageSignaturesV13.sigExamples)
+  runSym[SyncIO](HttpMessageSignaturesV13.symSignExamples)
 }

--- a/core/jvm/src/test/scala/bobcats/PEMTestSuite.scala
+++ b/core/jvm/src/test/scala/bobcats/PEMTestSuite.scala
@@ -24,7 +24,7 @@ import scala.util.Try
 class PEMTestSuite extends munit.FunSuite {
   import util.{BouncyJavaPEMUtils => pemutils}
 
-  SigningHttpMessages.keyExamples.foreach(testPEM)
+  HttpMessageSignaturesV07.keyExamples.foreach(testPEM)
 
   def testPEM(pem: TestKeyPair): Unit = {
     test(s"${pem.description}: test spec public key matches calculated spki key") {

--- a/core/shared/src/main/scala/bobcats/Algorithm.scala
+++ b/core/shared/src/main/scala/bobcats/Algorithm.scala
@@ -180,8 +180,7 @@ object AsymmetricKeyAlg {
   // note PSS requires extra arguments to be passed.
   case object `rsa-pss-sha512` extends RSA_PSS_Sig {
     override def saltLength: Int = 64
-    override def hash: HashAlgorithm =
-      HashAlgorithm.SHA512 // is this right? OR should it be optional?
+    override def hash: HashAlgorithm = HashAlgorithm.SHA512
   }
 
   case object `rsa-v1_5-sha256` extends RSA_PKCS_Sig {
@@ -202,7 +201,7 @@ object AsymmetricKeyAlg {
       HashAlgorithm.SHA256 // is this right? OR should it be optional?
   }
 
-  case object `ed25119-pure` extends Ed_Sig {
+  case object `ed25119` extends Ed_Sig {
     override def hash: HashAlgorithm = ??? // no hash? Should hash then be Option?
     override private[bobcats] def toStringJava = "Ed25519"
     override private[bobcats] def toStringNodeJS = ???

--- a/core/shared/src/test/scala/bobcats/HmacSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HmacSuite.scala
@@ -32,7 +32,7 @@ class HmacSuite extends CatsEffectSuite {
   val data = ByteVector.encodeAscii("The quick brown fox jumps over the lazy dog").toOption.get
 
   def testHmac[F[_]: Hmac: Functor](algorithm: HmacAlgorithm, expect: String)(
-      implicit ct: ClassTag[F[Nothing]]) =
+      implicit ct: ClassTag[F[Nothing]]): Unit =
     test(s"$algorithm with ${ct.runtimeClass.getSimpleName()}") {
       Hmac[F].digest(SecretKeySpec(key, algorithm), data).map { obtained =>
         assertEquals(

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV07.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV07.scala
@@ -56,7 +56,7 @@ object HttpMessageSignaturesV07 extends AsymmetricKeyExamples {
         signature = """crVqK54rxvdx0j7qnt2RL1oQSf+o21S/6Uk2hyFpoIfOT0q+Hv\
 		  |  msYAXUXzo0Wn8NFWh/OjWQOXHAQdVnTk87Pw==""".rfc8792single,
         keypair = `test-key-ecc-p256`,
-        signatureAlg = AsymmetricKeyAlg.`ecdsa-p256-sha256` //? is this correct?
+        signatureAlg = AsymmetricKeyAlg.`ecdsa-p256-sha256` // ? is this correct?
       )
 
   object `§3.1_Signature`

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV07.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV07.scala
@@ -192,7 +192,7 @@ object HttpMessageSignaturesV07 extends AsymmetricKeyExamples {
         signature = """u9DvOJe17NdTTuIJjKac9WncuAo/1d4gOh6TXMV6AN4hxLdttB\
                       |  SegWS/RcWPZ+lENCtykh6YGl8GJiQrxgibBg==""".rfc8792single,
         keypair = `test-key-ed25519`,
-        signatureAlg = bobcats.AsymmetricKeyAlg.`ed25119-pure`
+        signatureAlg = bobcats.AsymmetricKeyAlg.ed25119
       )
 
   // 2048-bit RSA public and private key pair,

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV07.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV07.scala
@@ -405,6 +405,21 @@ object HttpMessageSignaturesV07 extends AsymmetricKeyExamples {
         |-----END PUBLIC KEY-----""".stripMargin
 
     override def keyAlg: AsymmetricKeyAlg = AsymmetricKeyAlg.Ed25519_Key
+
+    /**
+     * platform limitation descriptions that can be used to filter out tests and also provide
+     * some readalbe documentation
+     */
+    override def limitation: Set[NotFor] = Set(
+      NoWebCryptAPI(
+        "At the moment: On 6 Nov 2022 only Node.js and Deno runtimes implement Ed25519 as per Secure Curves " +
+          "in the Web Cryptography API.",
+        List(
+          new java.net.URI(
+            "https://github.com/httpwg/http-extensions/issues/2290#issuecomment-1304763239"),
+          new java.net.URI("https://wicg.github.io/webcrypto-secure-curves/")
+        )
+      ))
   }
 
 }

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV07.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV07.scala
@@ -25,9 +25,9 @@ import bobcats.SignatureExample._
  * @see
  *   https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html
  */
-object SigningHttpMessages extends AsymmetricKeyExamples {
+object HttpMessageSignaturesV07 extends AsymmetricKeyExamples {
 
-  def signatureExamples: Seq[SignatureExample] = Seq(
+  def sigExamples: Seq[SignatureExample] = Seq(
     `§2.2.11_Example`,
     `§3.1_Signature`,
     `§4.3_Example`,
@@ -36,13 +36,6 @@ object SigningHttpMessages extends AsymmetricKeyExamples {
     `Appendix_B.2.3`,
     `Appendix_B.2.4`,
     `Github-Issue-1509-Example`
-  )
-
-  override def keyExamples: Seq[TestKeyPair] = Seq(
-    `test-key-rsa`,
-    `test-key-rsa-pss`,
-    `test-key-ecc-p256`,
-    `test-key-ed25519`
   )
 
   object `§2.2.11_Example`
@@ -63,7 +56,7 @@ object SigningHttpMessages extends AsymmetricKeyExamples {
         signature = """crVqK54rxvdx0j7qnt2RL1oQSf+o21S/6Uk2hyFpoIfOT0q+Hv\
 		  |  msYAXUXzo0Wn8NFWh/OjWQOXHAQdVnTk87Pw==""".rfc8792single,
         keypair = `test-key-ecc-p256`,
-        signatureAlg = AsymmetricKeyAlg.`ecdsa-p256-sha256`
+        signatureAlg = AsymmetricKeyAlg.`ecdsa-p256-sha256` //? is this correct?
       )
 
   object `§3.1_Signature`
@@ -399,7 +392,7 @@ object SigningHttpMessages extends AsymmetricKeyExamples {
   }
 
   object `test-key-ed25519` extends TestKeyPair {
-    override def description: String = "Ed25519 key"
+    override def description: String = "test-key-ed25519"
 
     override def privateKey: PrivateKeyPEM =
       """-----BEGIN PRIVATE KEY-----

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
@@ -172,7 +172,7 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
 
   object `Appendix_B.2.6`
       extends SignatureExample(
-        description = "Abbpendix B.2.6 Signing a Request using ed25519",
+        description = "Appendix B.2.6 Signing a Request using ed25519",
         sigtext = """\
        |"date": Tue, 20 Apr 2021 02:07:55 GMT
        |"@method": POST

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
@@ -234,14 +234,23 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
   // thanks to sjrd for this tip
   def isJS: Boolean = 1.0.toString() == "1"
 
-  // 2048-bit RSA public and private key pair,
-  // given in https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#appendix-B.1.1
-  // this key did not change
+  /**
+   * 2048-bit RSA public and private key pair, given in
+   * https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#appendix-B.1.1
+   * this key did not change note: the private key needed to be updated to pkcs8
+   */
   val `test-key-rsa` = HttpMessageSignaturesV07.`test-key-rsa`
 
   /**
    * 2048-bit RSA public and private key pair taken from
    * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.2 draft 13 Appendix B.1.2]]
+   * @panva
+   *   [https://github.com/w3c/webcrypto/issues/330#issuecomment-1304759709 wrote on the
+   *   webcrypto](https://github.com/w3c/webcrypto/issues/330#issuecomment-1304759709) issue:
+   *   "The private key in appendix-B.1.2 is 1.2.840.113549.1.1.10 (id-RSASSA-PSS). WebCryptoAPI
+   *   implementations only generally accept 1.2.840.113549.1.1.1 (rsaEncryption) keys.
+   *   Recommend using rsaEncryption OID PKCS8 PEM or JWK if they ought to be imported as
+   *   CryptoKey reliably."
    */
   def `test-key-rsa-pss` = if (isJS)
     HttpMessageSignaturesV07.`test-key-rsa-pss`
@@ -299,7 +308,11 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
   /**
    * Taken from
    * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.3 draft 13 Appendix B.1.3]]
-   * This did not change from draft 7
+   * But as panva tells us on
+   * [[https://github.com/w3c/webcrypto/issues/330#issuecomment-1304759709 issue 330 of webcrypto]]:
+   * "The private key in appendix-B.1.3 is in SEC1 format, which isn't accepted by webcrypto at
+   * all. Recommend using id-ecPublicKey OID PKCS8 PEM or JWK if they ought to be imported as
+   * CryptoKey reliably." We somehow managed to update the key to the correct version in v07.
    */
   val `test-key-ecc-p256`: TestKeyPair = HttpMessageSignaturesV07.`test-key-ecc-p256`
 

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
@@ -16,7 +16,7 @@
 
 package bobcats
 
-import bobcats.SignatureExample.{Base64Bytes, PublicKeyPEM}
+import bobcats.SignatureExample.Base64Bytes
 import util.StringUtils.StringW
 
 /**
@@ -172,11 +172,13 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
   // this key did not change
   val `test-key-rsa` = HttpMessageSignaturesV07.`test-key-rsa`
 
-//  val `test-key-rsa-pss` = HttpMessageSignaturesV07.`test-key-rsa-pss`
+  val `test-key-rsa-pss` = HttpMessageSignaturesV07.`test-key-rsa-pss`
+
   /**
    * 2048-bit RSA public and private key pair taken from
    * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.2 draft 13 Appendix B.1.2]]
    */
+  /*
   object `test-key-rsa-pss` extends TestKeyPair {
     override def description: String = "test-key-rsa-pss"
 
@@ -226,6 +228,7 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
 
     override def keyAlg: AsymmetricKeyAlg = AsymmetricKeyAlg.RSA_PSS_Key
   }
+   */
 
   /**
    * Taken from

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
@@ -21,8 +21,8 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
     `§2.4_Example`,
     `§2.5_Example`,
     `Appendix_B.2.2`,
-//    `Appendix_B.2.3`,
-    `Appendix_B.2.4`,
+    `Appendix_B.2.3`,
+    `Appendix_B.2.4`
   )
 
   object `§2.4_Example`
@@ -122,9 +122,10 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
       )
 
   object `Appendix_B.2.4`
-    extends SignatureExample(
-      description = "Signing a Response using ecdsa-p256-sha256",
-      sigtext = """\
+      extends SignatureExample(
+        description = "Signing a Response using ecdsa-p256-sha256",
+        sigtext =
+          """\
            |"@status": 200
            |"content-type": application/json
            |"content-digest": sha-512=:mEWXIS7MaLRuGgxOBdODa3xqM1XdEvxoYhvlCFJ4\
@@ -132,108 +133,110 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
            |"content-length": 23
            |"@signature-params": ("@status" "content-type" "content-digest" \
            |  "content-length");created=1618884473;keyid="test-key-ecc-p256"""".rfc8792single,
-      signature = """wNmSUAhwb5LxtOtOpNa6W5xj067m5hFrj0XQ4fvpaCLx0NK\
+        signature = """wNmSUAhwb5LxtOtOpNa6W5xj067m5hFrj0XQ4fvpaCLx0NK\
            ocgPquLgyahnzDnDAUy5eCdlYUEkLIj+32oiasw==""".rfc8792single,
-      keypair = `test-key-ecc-p256`,
-      signatureAlg = AsymmetricKeyAlg.`ecdsa-p256-sha256`)
-      
-   object `Appendix_B.2.5` extends SymmetricSignatureExample(
-     description = "Appendix B.2.5 Signing a Request using symmetric key hmac-sha256",
-     sigtext = """\
+        keypair = `test-key-ecc-p256`,
+        signatureAlg = AsymmetricKeyAlg.`ecdsa-p256-sha256`)
+
+  object `Appendix_B.2.5`
+      extends SymmetricSignatureExample(
+        description = "Appendix B.2.5 Signing a Request using symmetric key hmac-sha256",
+        sigtext = """\
         |"date": Tue, 20 Apr 2021 02:07:55 GMT
         |"@authority": example.com
         |"content-type": application/json
         |"@signature-params": ("date" "@authority" "content-type")\
         |  ;created=1618884473;keyid="test-shared-secret"""".rfc8792single,
-     signature = """pxcQw6G3AjtMBQjwo8XzkZf/bws5LelbaMk5rGIGtE8=""",
-     key = `test-shared-secret`,
-     signatureAlg = HmacAlgorithm.SHA256)
+        signature = """pxcQw6G3AjtMBQjwo8XzkZf/bws5LelbaMk5rGIGtE8=""",
+        key = `test-shared-secret`,
+        signatureAlg = HmacAlgorithm.SHA256)
 
   // 2048-bit RSA public and private key pair,
   // given in https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#appendix-B.1.1
   // this key did not change
   val `test-key-rsa` = HttpMessageSignaturesV07.`test-key-rsa`
 
-  /**
-   * 2048-bit RSA public and private key pair taken from
-   * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.2 draft 13 Appendix B.1.2]]
-   */
-  object `test-key-rsa-pss` extends TestKeyPair {
-    override def description: String = "test-key-rsa-pss"
-
-    override def privateKey: PrivateKeyPEM =
-      """-----BEGIN PRIVATE KEY-----
-        |MIIEvgIBADALBgkqhkiG9w0BAQoEggSqMIIEpgIBAAKCAQEAr4tmm3r20Wd/Pbqv
-        |P1s2+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry5
-        |3mm+oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7Oyr
-        |FAHqgDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUA
-        |AN5WUtzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw
-        |9lq4aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oy
-        |c6XI2wIDAQABAoIBAQCUB8ip+kJiiZVKF8AqfB/aUP0jTAqOQewK1kKJ/iQCXBCq
-        |pbo360gvdt05H5VZ/RDVkEgO2k73VSsbulqezKs8RFs2tEmU+JgTI9MeQJPWcP6X
-        |aKy6LIYs0E2cWgp8GADgoBs8llBq0UhX0KffglIeek3n7Z6Gt4YFge2TAcW2WbN4
-        |XfK7lupFyo6HHyWRiYHMMARQXLJeOSdTn5aMBP0PO4bQyk5ORxTUSeOciPJUFktQ
-        |HkvGbym7KryEfwH8Tks0L7WhzyP60PL3xS9FNOJi9m+zztwYIXGDQuKM2GDsITeD
-        |2mI2oHoPMyAD0wdI7BwSVW18p1h+jgfc4dlexKYRAoGBAOVfuiEiOchGghV5vn5N
-        |RDNscAFnpHj1QgMr6/UG05RTgmcLfVsI1I4bSkbrIuVKviGGf7atlkROALOG/xRx
-        |DLadgBEeNyHL5lz6ihQaFJLVQ0u3U4SB67J0YtVO3R6lXcIjBDHuY8SjYJ7Ci6Z6
-        |vuDcoaEujnlrtUhaMxvSfcUJAoGBAMPsCHXte1uWNAqYad2WdLjPDlKtQJK1diCm
-        |rqmB2g8QE99hDOHItjDBEdpyFBKOIP+NpVtM2KLhRajjcL9Ph8jrID6XUqikQuVi
-        |4J9FV2m42jXMuioTT13idAILanYg8D3idvy/3isDVkON0X3UAVKrgMEne0hJpkPL
-        |FYqgetvDAoGBAKLQ6JZMbSe0pPIJkSamQhsehgL5Rs51iX4m1z7+sYFAJfhvN3Q/
-        |OGIHDRp6HjMUcxHpHw7U+S1TETxePwKLnLKj6hw8jnX2/nZRgWHzgVcY+sPsReRx
-        |NJVf+Cfh6yOtznfX00p+JWOXdSY8glSSHJwRAMog+hFGW1AYdt7w80XBAoGBAImR
-        |NUugqapgaEA8TrFxkJmngXYaAqpA0iYRA7kv3S4QavPBUGtFJHBNULzitydkNtVZ
-        |3w6hgce0h9YThTo/nKc+OZDZbgfN9s7cQ75x0PQCAO4fx2P91Q+mDzDUVTeG30mE
-        |t2m3S0dGe47JiJxifV9P3wNBNrZGSIF3mrORBVNDAoGBAI0QKn2Iv7Sgo4T/XjND
-        |dl2kZTXqGAk8dOhpUiw/HdM3OGWbhHj2NdCzBliOmPyQtAr770GITWvbAI+IRYyF
-        |S7Fnk6ZVVVHsxjtaHy1uJGFlaZzKR4AGNaUTOJMs6NadzCmGPAxNQQOCqoUjn4XR
-        |rOjr9w349JooGXhOxbu8nOxX
-        |-----END PRIVATE KEY-----""".stripMargin
-
-    override def privatePk8Key: PrivateKeyPEM =
-    """-----BEGIN RSA PRIVATE KEY-----
-      |MIIEpgIBAAKCAQEAr4tmm3r20Wd/PbqvP1s2+QEtvpuRaV8Yq40gjUR8y2Rjxa6d
-      |pG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry53mm+oAXjyQ86OnDkZ5N8lYbggD4O3w6M
-      |6pAvLkhk95AndTrifbIFPNU8PPMO7OyrFAHqgDsznjPFmTOtCEcN2Z1FpWgchwuY
-      |LPL+Wokqltd11nqqzi+bJ9cvSKADYdUAAN5WUtzdpiy6LbTgSxP7ociU4Tn0g5I6
-      |aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw9lq4aOT9v6d+nb4bnNkQVklLQ3fVAvJm
-      |+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI2wIDAQABAoIBAQCUB8ip+kJiiZVK
-      |F8AqfB/aUP0jTAqOQewK1kKJ/iQCXBCqpbo360gvdt05H5VZ/RDVkEgO2k73VSsb
-      |ulqezKs8RFs2tEmU+JgTI9MeQJPWcP6XaKy6LIYs0E2cWgp8GADgoBs8llBq0UhX
-      |0KffglIeek3n7Z6Gt4YFge2TAcW2WbN4XfK7lupFyo6HHyWRiYHMMARQXLJeOSdT
-      |n5aMBP0PO4bQyk5ORxTUSeOciPJUFktQHkvGbym7KryEfwH8Tks0L7WhzyP60PL3
-      |xS9FNOJi9m+zztwYIXGDQuKM2GDsITeD2mI2oHoPMyAD0wdI7BwSVW18p1h+jgfc
-      |4dlexKYRAoGBAOVfuiEiOchGghV5vn5NRDNscAFnpHj1QgMr6/UG05RTgmcLfVsI
-      |1I4bSkbrIuVKviGGf7atlkROALOG/xRxDLadgBEeNyHL5lz6ihQaFJLVQ0u3U4SB
-      |67J0YtVO3R6lXcIjBDHuY8SjYJ7Ci6Z6vuDcoaEujnlrtUhaMxvSfcUJAoGBAMPs
-      |CHXte1uWNAqYad2WdLjPDlKtQJK1diCmrqmB2g8QE99hDOHItjDBEdpyFBKOIP+N
-      |pVtM2KLhRajjcL9Ph8jrID6XUqikQuVi4J9FV2m42jXMuioTT13idAILanYg8D3i
-      |dvy/3isDVkON0X3UAVKrgMEne0hJpkPLFYqgetvDAoGBAKLQ6JZMbSe0pPIJkSam
-      |QhsehgL5Rs51iX4m1z7+sYFAJfhvN3Q/OGIHDRp6HjMUcxHpHw7U+S1TETxePwKL
-      |nLKj6hw8jnX2/nZRgWHzgVcY+sPsReRxNJVf+Cfh6yOtznfX00p+JWOXdSY8glSS
-      |HJwRAMog+hFGW1AYdt7w80XBAoGBAImRNUugqapgaEA8TrFxkJmngXYaAqpA0iYR
-      |A7kv3S4QavPBUGtFJHBNULzitydkNtVZ3w6hgce0h9YThTo/nKc+OZDZbgfN9s7c
-      |Q75x0PQCAO4fx2P91Q+mDzDUVTeG30mEt2m3S0dGe47JiJxifV9P3wNBNrZGSIF3
-      |mrORBVNDAoGBAI0QKn2Iv7Sgo4T/XjNDdl2kZTXqGAk8dOhpUiw/HdM3OGWbhHj2
-      |NdCzBliOmPyQtAr770GITWvbAI+IRYyFS7Fnk6ZVVVHsxjtaHy1uJGFlaZzKR4AG
-      |NaUTOJMs6NadzCmGPAxNQQOCqoUjn4XRrOjr9w349JooGXhOxbu8nOxX
-      |-----END RSA PRIVATE KEY-----"""
-        
-    
-    override def publicKey: PublicKeyPEM =
-      """-----BEGIN PUBLIC KEY-----
-        |MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4tmm3r20Wd/PbqvP1s2
-        |+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry53mm+
-        |oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7OyrFAHq
-        |gDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUAAN5W
-        |Utzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw9lq4
-        |aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI
-        |2wIDAQAB
-        |-----END PUBLIC KEY-----"""".stripMargin
-
-    override def keyAlg: AsymmetricKeyAlg = AsymmetricKeyAlg.RSA_PSS_Key
-  }
+  val `test-key-rsa-pss` = HttpMessageSignaturesV07.`test-key-rsa-pss`
+//  /**
+//   * 2048-bit RSA public and private key pair taken from
+//   * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.2 draft 13 Appendix B.1.2]]
+//   */
+//  object `test-key-rsa-pss` extends TestKeyPair {
+//    override def description: String = "test-key-rsa-pss"
+//
+//    override def privateKey: PrivateKeyPEM =
+//      """-----BEGIN PRIVATE KEY-----
+//        |MIIEvgIBADALBgkqhkiG9w0BAQoEggSqMIIEpgIBAAKCAQEAr4tmm3r20Wd/Pbqv
+//        |P1s2+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry5
+//        |3mm+oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7Oyr
+//        |FAHqgDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUA
+//        |AN5WUtzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw
+//        |9lq4aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oy
+//        |c6XI2wIDAQABAoIBAQCUB8ip+kJiiZVKF8AqfB/aUP0jTAqOQewK1kKJ/iQCXBCq
+//        |pbo360gvdt05H5VZ/RDVkEgO2k73VSsbulqezKs8RFs2tEmU+JgTI9MeQJPWcP6X
+//        |aKy6LIYs0E2cWgp8GADgoBs8llBq0UhX0KffglIeek3n7Z6Gt4YFge2TAcW2WbN4
+//        |XfK7lupFyo6HHyWRiYHMMARQXLJeOSdTn5aMBP0PO4bQyk5ORxTUSeOciPJUFktQ
+//        |HkvGbym7KryEfwH8Tks0L7WhzyP60PL3xS9FNOJi9m+zztwYIXGDQuKM2GDsITeD
+//        |2mI2oHoPMyAD0wdI7BwSVW18p1h+jgfc4dlexKYRAoGBAOVfuiEiOchGghV5vn5N
+//        |RDNscAFnpHj1QgMr6/UG05RTgmcLfVsI1I4bSkbrIuVKviGGf7atlkROALOG/xRx
+//        |DLadgBEeNyHL5lz6ihQaFJLVQ0u3U4SB67J0YtVO3R6lXcIjBDHuY8SjYJ7Ci6Z6
+//        |vuDcoaEujnlrtUhaMxvSfcUJAoGBAMPsCHXte1uWNAqYad2WdLjPDlKtQJK1diCm
+//        |rqmB2g8QE99hDOHItjDBEdpyFBKOIP+NpVtM2KLhRajjcL9Ph8jrID6XUqikQuVi
+//        |4J9FV2m42jXMuioTT13idAILanYg8D3idvy/3isDVkON0X3UAVKrgMEne0hJpkPL
+//        |FYqgetvDAoGBAKLQ6JZMbSe0pPIJkSamQhsehgL5Rs51iX4m1z7+sYFAJfhvN3Q/
+//        |OGIHDRp6HjMUcxHpHw7U+S1TETxePwKLnLKj6hw8jnX2/nZRgWHzgVcY+sPsReRx
+//        |NJVf+Cfh6yOtznfX00p+JWOXdSY8glSSHJwRAMog+hFGW1AYdt7w80XBAoGBAImR
+//        |NUugqapgaEA8TrFxkJmngXYaAqpA0iYRA7kv3S4QavPBUGtFJHBNULzitydkNtVZ
+//        |3w6hgce0h9YThTo/nKc+OZDZbgfN9s7cQ75x0PQCAO4fx2P91Q+mDzDUVTeG30mE
+//        |t2m3S0dGe47JiJxifV9P3wNBNrZGSIF3mrORBVNDAoGBAI0QKn2Iv7Sgo4T/XjND
+//        |dl2kZTXqGAk8dOhpUiw/HdM3OGWbhHj2NdCzBliOmPyQtAr770GITWvbAI+IRYyF
+//        |S7Fnk6ZVVVHsxjtaHy1uJGFlaZzKR4AGNaUTOJMs6NadzCmGPAxNQQOCqoUjn4XR
+//        |rOjr9w349JooGXhOxbu8nOxX
+//        |-----END PRIVATE KEY-----""".stripMargin
+//
+//    override def privatePk8Key: PrivateKeyPEM =
+//      """-----BEGIN PRIVATE KEY-----
+//        |MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQCvi2abevbRZ389
+//        |uq8/Wzb5AS2+m5FpXxirjSCNRHzLZGPFrp2kbYZcds9+8yzxy34uHUYfjnHbxHDd
+//        |HLneab6gBePJDzo6cORnk3yVhuCAPg7fDozqkC8uSGT3kCd1OuJ9sgU81Tw88w7s
+//        |7KsUAeqAOzOeM8WZM60IRw3ZnUWlaByHC5gs8v5aiSqW13XWeqrOL5sn1y9IoANh
+//        |1QAA3lZS3N2mLLottOBLE/uhyJThOfSDkjpoNknsDwvOjQpLJligDjzmapw7QZUB
+//        |1XD2Wrho5P2/p36dvhuc2RBWSUtDd9UC8mb7F0M6n0sI0I3jxXamcM6QVXr5T2dX
+//        |mjJzpcjbAgMBAAECggEBAJQHyKn6QmKJlUoXwCp8H9pQ/SNMCo5B7ArWQon+JAJc
+//        |EKqlujfrSC923TkflVn9ENWQSA7aTvdVKxu6Wp7MqzxEWza0SZT4mBMj0x5Ak9Zw
+//        |/pdorLoshizQTZxaCnwYAOCgGzyWUGrRSFfQp9+CUh56Teftnoa3hgWB7ZMBxbZZ
+//        |s3hd8ruW6kXKjocfJZGJgcwwBFBcsl45J1OflowE/Q87htDKTk5HFNRJ45yI8lQW
+//        |S1AeS8ZvKbsqvIR/AfxOSzQvtaHPI/rQ8vfFL0U04mL2b7PO3BghcYNC4ozYYOwh
+//        |N4PaYjageg8zIAPTB0jsHBJVbXynWH6OB9zh2V7EphECgYEA5V+6ISI5yEaCFXm+
+//        |fk1EM2xwAWekePVCAyvr9QbTlFOCZwt9WwjUjhtKRusi5Uq+IYZ/tq2WRE4As4b/
+//        |FHEMtp2AER43IcvmXPqKFBoUktVDS7dThIHrsnRi1U7dHqVdwiMEMe5jxKNgnsKL
+//        |pnq+4NyhoS6OeWu1SFozG9J9xQkCgYEAw+wIde17W5Y0Cphp3ZZ0uM8OUq1AkrV2
+//        |IKauqYHaDxAT32EM4ci2MMER2nIUEo4g/42lW0zYouFFqONwv0+HyOsgPpdSqKRC
+//        |5WLgn0VXabjaNcy6KhNPXeJ0AgtqdiDwPeJ2/L/eKwNWQ43RfdQBUquAwSd7SEmm
+//        |Q8sViqB628MCgYEAotDolkxtJ7Sk8gmRJqZCGx6GAvlGznWJfibXPv6xgUAl+G83
+//        |dD84YgcNGnoeMxRzEekfDtT5LVMRPF4/AoucsqPqHDyOdfb+dlGBYfOBVxj6w+xF
+//        |5HE0lV/4J+HrI63Od9fTSn4lY5d1JjyCVJIcnBEAyiD6EUZbUBh23vDzRcECgYEA
+//        |iZE1S6CpqmBoQDxOsXGQmaeBdhoCqkDSJhEDuS/dLhBq88FQa0UkcE1QvOK3J2Q2
+//        |1VnfDqGBx7SH1hOFOj+cpz45kNluB832ztxDvnHQ9AIA7h/HY/3VD6YPMNRVN4bf
+//        |SYS3abdLR0Z7jsmInGJ9X0/fA0E2tkZIgXeas5EFU0MCgYEAjRAqfYi/tKCjhP9e
+//        |M0N2XaRlNeoYCTx06GlSLD8d0zc4ZZuEePY10LMGWI6Y/JC0CvvvQYhNa9sAj4hF
+//        |jIVLsWeTplVVUezGO1ofLW4kYWVpnMpHgAY1pRM4kyzo1p3MKYY8DE1BA4KqhSOf
+//        |hdGs6Ov3Dfj0migZeE7Fu7yc7Fc=
+//        |-----END PRIVATE KEY-----""".stripMargin
+//
+//    override def publicKey: PublicKeyPEM =
+//      """-----BEGIN PUBLIC KEY-----
+//        |MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4tmm3r20Wd/PbqvP1s2
+//        |+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry53mm+
+//        |oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7OyrFAHq
+//        |gDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUAAN5W
+//        |Utzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw9lq4
+//        |aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI
+//        |2wIDAQAB
+//        |-----END PUBLIC KEY-----"""".stripMargin
+//
+//    override def keyAlg: AsymmetricKeyAlg = AsymmetricKeyAlg.RSA_PSS_Key
+//  }
 
   /**
    * Taken from

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
@@ -1,0 +1,263 @@
+package bobcats
+
+import bobcats.SignatureExample.Base64Bytes
+import util.StringUtils.StringW
+
+/**
+ * Examples taken from Signing HTTP Messages RFC draft 13
+ *
+ * @see
+ *   https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures
+ */
+object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyExamples {
+
+  import SignatureExample.{PrivateKeyPEM, PublicKeyPEM}
+
+  override def symSignExamples: Seq[SymmetricSignatureExample] = Seq(
+    `Appendix_B.2.5`
+  )
+
+  def sigExamples: Seq[SignatureExample] = Seq(
+    `§2.4_Example`,
+    `§2.5_Example`,
+    `Appendix_B.2.2`,
+//    `Appendix_B.2.3`,
+    `Appendix_B.2.4`,
+  )
+
+  object `§2.4_Example`
+      extends SignatureExample(
+        description = "Request-Response Signature Binding",
+        sigtext = """\
+       |"@status": 503
+       |"content-length": 62
+       |"content-type": application/json
+       |"signature";req;key="sig1": :LAH8BjcfcOcLojiuOBFWn0P5keD3xAOuJRGziC\
+       |  LuD8r5MW9S0RoXXLzLSRfGY/3SF8kVIkHjE13SEFdTo4Af/fJ/Pu9wheqoLVdwXyY\
+       |  /UkBIS1M8Brc8IODsn5DFIrG0IrburbLi0uCc+E2ZIIb6HbUJ+o+jP58JelMTe0QE\
+       |  3IpWINTEzpxjqDf5/Df+InHCAkQCTuKsamjWXUpyOT1Wkxi7YPVNOjW4MfNuTZ9Hd\
+       |  bD2Tr65+BXeTG9ZS/9SWuXAc+BZ8WyPz0QRz//ec3uWXd7bYYODSjRAxHqX+S1ag3\
+       |  LZElYyUKaAIjZ8MGOt4gXEwCSLDv/zqxZeWLj/PDkn6w==:
+       |"@authority";req: example.com
+       |"@method";req: POST
+       |"@signature-params": ("@status" "content-length" "content-type" \
+       |  "signature";req;key="sig1" "@authority";req "@method";req)\
+       |  ;created=1618884479;keyid="test-key-ecc-p256"""".rfc8792single,
+        signature = """mh17P4TbYYBmBwsXPT4nsyVzW4Rp9Fb8WcvnfqKCQLoMvzOB\
+          LD/n32tL/GPW6XE5GAS5bdsg1khK6lBzV1Cx/Q==""".rfc8792single,
+        keypair = `test-key-ecc-p256`,
+        signatureAlg = AsymmetricKeyAlg.`ecdsa-p256-sha256` // ? is this correct?
+      )
+
+  object `§2.5_Example`
+      extends SignatureExample(
+        description = "Example from §2.5 signed in §3.1",
+        sigtext = """\
+      |"@method": POST
+      |"@authority": example.com
+      |"@path": /foo
+      |"content-digest": sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX\
+      |  +TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:
+      |"content-length": 18
+      |"content-type": application/json
+      |"@signature-params": ("@method" "@authority" "@path" \
+      |  "content-digest" "content-length" "content-type")\
+      |  ;created=1618884473;keyid="test-key-rsa-pss"""".rfc8792single,
+        signature = """HIbjHC5rS0BYaa9v4QfD4193TORw7u9edguPh0AW3dMq9WImrlFrCGUDih47vAxi4L2\
+       YRZ3XMJc1uOKk/J0ZmZ+wcta4nKIgBkKq0rM9hs3CQyxXGxHLMCy8uqK488o+9jrptQ\
+       +xFPHK7a9sRL1IXNaagCNN3ZxJsYapFj+JXbmaI5rtAdSfSvzPuBCh+ARHBmWuNo1Uz\
+       VVdHXrl8ePL4cccqlazIJdC4QEjrF+Sn4IxBQzTZsL9y9TP5FsZYzHvDqbInkTNigBc\
+       E9cKOYNFCn4D/WM7F6TNuZO9EgtzepLWcjTymlHzK7aXq6Am6sfOrpIC49yXjj3ae6H\
+       RalVc/g==""".rfc8792single,
+        keypair = `test-key-rsa-pss`,
+        signatureAlg = AsymmetricKeyAlg.`rsa-pss-sha512`
+      )
+
+  object `Appendix_B.2.2`
+      extends SignatureExample(
+        description = "Selective Covered Components using rsa-pss-sha512",
+        sigtext = """\
+        |"@authority": example.com
+        |"content-digest": sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX\
+        |  +TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:
+        |"@query-param";name="Pet": dog
+        |"@signature-params": ("@authority" "content-digest" \
+        |  "@query-param";name="Pet")\
+        |  ;created=1618884473;keyid="test-key-rsa-pss"\
+        |  ;tag="header-example"""".rfc8792single,
+        signature = """LjbtqUbfmvjj5C5kr1Ugj4PmLYvx9wVjZvD9GsTT4F7GrcQ\
+         EdJzgI9qHxICagShLRiLMlAJjtq6N4CDfKtjvuJyE5qH7KT8UCMkSowOB4+ECxCmT\
+         8rtAmj/0PIXxi0A0nxKyB09RNrCQibbUjsLS/2YyFYXEu4TRJQzRw1rLEuEfY17SA\
+         RYhpTlaqwZVtR8NV7+4UKkjqpcAoFqWFQh62s7Cl+H2fjBSpqfZUJcsIk4N6wiKYd\
+         4je2U/lankenQ99PZfB4jY3I5rSV2DSBVkSFsURIjYErOs0tFTQosMTAoxk//0RoK\
+         UqiYY8Bh0aaUEb0rQl3/XaVe4bXTugEjHSw==""".rfc8792single,
+        keypair = `test-key-rsa-pss`,
+        signatureAlg = AsymmetricKeyAlg.`rsa-pss-sha512`
+      )
+
+  object `Appendix_B.2.3`
+      extends SignatureExample(
+        description = "Full Coverage using rsa-pss-sha512",
+        sigtext = """\
+      |"date": Tue, 20 Apr 2021 02:07:55 GMT
+      |"@method": POST
+      |"@path": /foo
+      |"@query": ?param=Value&Pet=dog
+      |"@authority": example.com
+      |"content-type": application/json
+      |"content-digest": sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX\
+      |  +TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:
+      |"content-length": 18
+      |"@signature-params": ("date" "@method" "@path" "@query" \
+      |  "@authority" "content-type" "content-digest" "content-length")\
+      |  ;created=1618884473;keyid="test-key-rsa-pss"""".rfc8792single,
+        signature = """bbN8oArOxYoyylQQUU6QYwrTuaxLwjAC9fbY2F6SVWvh0yB\
+         iMIRGOnMYwZ/5MR6fb0Kh1rIRASVxFkeGt683+qRpRRU5p2voTp768ZrCUb38K0fU\
+         xN0O0iC59DzYx8DFll5GmydPxSmme9v6ULbMFkl+V5B1TP/yPViV7KsLNmvKiLJH1\
+         pFkh/aYA2HXXZzNBXmIkoQoLd7YfW91kE9o/CCoC1xMy7JA1ipwvKvfrs65ldmlu9\
+         bpG6A9BmzhuzF8Eim5f8ui9eH8LZH896+QIF61ka39VBrohr9iyMUJpvRX2Zbhl5Z\
+         JzSRxpJyoEZAFL2FUo5fTIztsDZKEgM4cUA==""".rfc8792single,
+        keypair = `test-key-rsa-pss`,
+        signatureAlg = AsymmetricKeyAlg.`rsa-pss-sha512`
+      )
+
+  object `Appendix_B.2.4`
+    extends SignatureExample(
+      description = "Signing a Response using ecdsa-p256-sha256",
+      sigtext = """\
+           |"@status": 200
+           |"content-type": application/json
+           |"content-digest": sha-512=:mEWXIS7MaLRuGgxOBdODa3xqM1XdEvxoYhvlCFJ4\
+           |  1QJgJc4GTsPp29l5oGX69wWdXymyU0rjJuahq4l5aGgfLQ==:
+           |"content-length": 23
+           |"@signature-params": ("@status" "content-type" "content-digest" \
+           |  "content-length");created=1618884473;keyid="test-key-ecc-p256"""".rfc8792single,
+      signature = """wNmSUAhwb5LxtOtOpNa6W5xj067m5hFrj0XQ4fvpaCLx0NK\
+           ocgPquLgyahnzDnDAUy5eCdlYUEkLIj+32oiasw==""".rfc8792single,
+      keypair = `test-key-ecc-p256`,
+      signatureAlg = AsymmetricKeyAlg.`ecdsa-p256-sha256`)
+      
+   object `Appendix_B.2.5` extends SymmetricSignatureExample(
+     description = "Appendix B.2.5 Signing a Request using symmetric key hmac-sha256",
+     sigtext = """\
+        |"date": Tue, 20 Apr 2021 02:07:55 GMT
+        |"@authority": example.com
+        |"content-type": application/json
+        |"@signature-params": ("date" "@authority" "content-type")\
+        |  ;created=1618884473;keyid="test-shared-secret"""".rfc8792single,
+     signature = """pxcQw6G3AjtMBQjwo8XzkZf/bws5LelbaMk5rGIGtE8=""",
+     key = `test-shared-secret`,
+     signatureAlg = HmacAlgorithm.SHA256)
+
+  // 2048-bit RSA public and private key pair,
+  // given in https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#appendix-B.1.1
+  // this key did not change
+  val `test-key-rsa` = HttpMessageSignaturesV07.`test-key-rsa`
+
+  /**
+   * 2048-bit RSA public and private key pair taken from
+   * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.2 draft 13 Appendix B.1.2]]
+   */
+  object `test-key-rsa-pss` extends TestKeyPair {
+    override def description: String = "test-key-rsa-pss"
+
+    override def privateKey: PrivateKeyPEM =
+      """-----BEGIN PRIVATE KEY-----
+        |MIIEvgIBADALBgkqhkiG9w0BAQoEggSqMIIEpgIBAAKCAQEAr4tmm3r20Wd/Pbqv
+        |P1s2+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry5
+        |3mm+oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7Oyr
+        |FAHqgDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUA
+        |AN5WUtzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw
+        |9lq4aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oy
+        |c6XI2wIDAQABAoIBAQCUB8ip+kJiiZVKF8AqfB/aUP0jTAqOQewK1kKJ/iQCXBCq
+        |pbo360gvdt05H5VZ/RDVkEgO2k73VSsbulqezKs8RFs2tEmU+JgTI9MeQJPWcP6X
+        |aKy6LIYs0E2cWgp8GADgoBs8llBq0UhX0KffglIeek3n7Z6Gt4YFge2TAcW2WbN4
+        |XfK7lupFyo6HHyWRiYHMMARQXLJeOSdTn5aMBP0PO4bQyk5ORxTUSeOciPJUFktQ
+        |HkvGbym7KryEfwH8Tks0L7WhzyP60PL3xS9FNOJi9m+zztwYIXGDQuKM2GDsITeD
+        |2mI2oHoPMyAD0wdI7BwSVW18p1h+jgfc4dlexKYRAoGBAOVfuiEiOchGghV5vn5N
+        |RDNscAFnpHj1QgMr6/UG05RTgmcLfVsI1I4bSkbrIuVKviGGf7atlkROALOG/xRx
+        |DLadgBEeNyHL5lz6ihQaFJLVQ0u3U4SB67J0YtVO3R6lXcIjBDHuY8SjYJ7Ci6Z6
+        |vuDcoaEujnlrtUhaMxvSfcUJAoGBAMPsCHXte1uWNAqYad2WdLjPDlKtQJK1diCm
+        |rqmB2g8QE99hDOHItjDBEdpyFBKOIP+NpVtM2KLhRajjcL9Ph8jrID6XUqikQuVi
+        |4J9FV2m42jXMuioTT13idAILanYg8D3idvy/3isDVkON0X3UAVKrgMEne0hJpkPL
+        |FYqgetvDAoGBAKLQ6JZMbSe0pPIJkSamQhsehgL5Rs51iX4m1z7+sYFAJfhvN3Q/
+        |OGIHDRp6HjMUcxHpHw7U+S1TETxePwKLnLKj6hw8jnX2/nZRgWHzgVcY+sPsReRx
+        |NJVf+Cfh6yOtznfX00p+JWOXdSY8glSSHJwRAMog+hFGW1AYdt7w80XBAoGBAImR
+        |NUugqapgaEA8TrFxkJmngXYaAqpA0iYRA7kv3S4QavPBUGtFJHBNULzitydkNtVZ
+        |3w6hgce0h9YThTo/nKc+OZDZbgfN9s7cQ75x0PQCAO4fx2P91Q+mDzDUVTeG30mE
+        |t2m3S0dGe47JiJxifV9P3wNBNrZGSIF3mrORBVNDAoGBAI0QKn2Iv7Sgo4T/XjND
+        |dl2kZTXqGAk8dOhpUiw/HdM3OGWbhHj2NdCzBliOmPyQtAr770GITWvbAI+IRYyF
+        |S7Fnk6ZVVVHsxjtaHy1uJGFlaZzKR4AGNaUTOJMs6NadzCmGPAxNQQOCqoUjn4XR
+        |rOjr9w349JooGXhOxbu8nOxX
+        |-----END PRIVATE KEY-----""".stripMargin
+
+    override def privatePk8Key: PrivateKeyPEM =
+    """-----BEGIN RSA PRIVATE KEY-----
+      |MIIEpgIBAAKCAQEAr4tmm3r20Wd/PbqvP1s2+QEtvpuRaV8Yq40gjUR8y2Rjxa6d
+      |pG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry53mm+oAXjyQ86OnDkZ5N8lYbggD4O3w6M
+      |6pAvLkhk95AndTrifbIFPNU8PPMO7OyrFAHqgDsznjPFmTOtCEcN2Z1FpWgchwuY
+      |LPL+Wokqltd11nqqzi+bJ9cvSKADYdUAAN5WUtzdpiy6LbTgSxP7ociU4Tn0g5I6
+      |aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw9lq4aOT9v6d+nb4bnNkQVklLQ3fVAvJm
+      |+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI2wIDAQABAoIBAQCUB8ip+kJiiZVK
+      |F8AqfB/aUP0jTAqOQewK1kKJ/iQCXBCqpbo360gvdt05H5VZ/RDVkEgO2k73VSsb
+      |ulqezKs8RFs2tEmU+JgTI9MeQJPWcP6XaKy6LIYs0E2cWgp8GADgoBs8llBq0UhX
+      |0KffglIeek3n7Z6Gt4YFge2TAcW2WbN4XfK7lupFyo6HHyWRiYHMMARQXLJeOSdT
+      |n5aMBP0PO4bQyk5ORxTUSeOciPJUFktQHkvGbym7KryEfwH8Tks0L7WhzyP60PL3
+      |xS9FNOJi9m+zztwYIXGDQuKM2GDsITeD2mI2oHoPMyAD0wdI7BwSVW18p1h+jgfc
+      |4dlexKYRAoGBAOVfuiEiOchGghV5vn5NRDNscAFnpHj1QgMr6/UG05RTgmcLfVsI
+      |1I4bSkbrIuVKviGGf7atlkROALOG/xRxDLadgBEeNyHL5lz6ihQaFJLVQ0u3U4SB
+      |67J0YtVO3R6lXcIjBDHuY8SjYJ7Ci6Z6vuDcoaEujnlrtUhaMxvSfcUJAoGBAMPs
+      |CHXte1uWNAqYad2WdLjPDlKtQJK1diCmrqmB2g8QE99hDOHItjDBEdpyFBKOIP+N
+      |pVtM2KLhRajjcL9Ph8jrID6XUqikQuVi4J9FV2m42jXMuioTT13idAILanYg8D3i
+      |dvy/3isDVkON0X3UAVKrgMEne0hJpkPLFYqgetvDAoGBAKLQ6JZMbSe0pPIJkSam
+      |QhsehgL5Rs51iX4m1z7+sYFAJfhvN3Q/OGIHDRp6HjMUcxHpHw7U+S1TETxePwKL
+      |nLKj6hw8jnX2/nZRgWHzgVcY+sPsReRxNJVf+Cfh6yOtznfX00p+JWOXdSY8glSS
+      |HJwRAMog+hFGW1AYdt7w80XBAoGBAImRNUugqapgaEA8TrFxkJmngXYaAqpA0iYR
+      |A7kv3S4QavPBUGtFJHBNULzitydkNtVZ3w6hgce0h9YThTo/nKc+OZDZbgfN9s7c
+      |Q75x0PQCAO4fx2P91Q+mDzDUVTeG30mEt2m3S0dGe47JiJxifV9P3wNBNrZGSIF3
+      |mrORBVNDAoGBAI0QKn2Iv7Sgo4T/XjNDdl2kZTXqGAk8dOhpUiw/HdM3OGWbhHj2
+      |NdCzBliOmPyQtAr770GITWvbAI+IRYyFS7Fnk6ZVVVHsxjtaHy1uJGFlaZzKR4AG
+      |NaUTOJMs6NadzCmGPAxNQQOCqoUjn4XRrOjr9w349JooGXhOxbu8nOxX
+      |-----END RSA PRIVATE KEY-----"""
+        
+    
+    override def publicKey: PublicKeyPEM =
+      """-----BEGIN PUBLIC KEY-----
+        |MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4tmm3r20Wd/PbqvP1s2
+        |+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry53mm+
+        |oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7OyrFAHq
+        |gDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUAAN5W
+        |Utzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw9lq4
+        |aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI
+        |2wIDAQAB
+        |-----END PUBLIC KEY-----"""".stripMargin
+
+    override def keyAlg: AsymmetricKeyAlg = AsymmetricKeyAlg.RSA_PSS_Key
+  }
+
+  /**
+   * Taken from
+   * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.3 draft 13 Appendix B.1.3]]
+   * This did not change from draft 7
+   */
+  val `test-key-ecc-p256` = HttpMessageSignaturesV07.`test-key-ecc-p256`
+
+  /**
+   * Taken from
+   * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.3 draft 13 Appendix B.1.4]]
+   * This did not change from draft 7
+   */
+  val `test-key-ed25519` = HttpMessageSignaturesV07.`test-key-ed25519`
+
+  /**
+   * Symmetric key from Appendix B.1.5
+   */
+  object `test-shared-secret` extends TestSharedKey {
+    override def sharedKey: Base64Bytes =
+      """uzvJfB4u3N0Jy4T7NZ75MDVcr8zSTInedJtkgcu46YW4XByzNJjxBdtjUkdJPBt
+        |bmHhIDi6pcl8jsasjlTMtDQ==""".stripMargin
+
+    override def description: PrivateKeyPEM = "test-shared-secret"
+  }
+
+}

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
@@ -16,7 +16,7 @@
 
 package bobcats
 
-import bobcats.SignatureExample.Base64Bytes
+import bobcats.SignatureExample.{Base64Bytes, PublicKeyPEM}
 import util.StringUtils.StringW
 
 /**
@@ -172,87 +172,60 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
   // this key did not change
   val `test-key-rsa` = HttpMessageSignaturesV07.`test-key-rsa`
 
-  val `test-key-rsa-pss` = HttpMessageSignaturesV07.`test-key-rsa-pss`
-//  /**
-//   * 2048-bit RSA public and private key pair taken from
-//   * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.2 draft 13 Appendix B.1.2]]
-//   */
-//  object `test-key-rsa-pss` extends TestKeyPair {
-//    override def description: String = "test-key-rsa-pss"
-//
-//    override def privateKey: PrivateKeyPEM =
-//      """-----BEGIN PRIVATE KEY-----
-//        |MIIEvgIBADALBgkqhkiG9w0BAQoEggSqMIIEpgIBAAKCAQEAr4tmm3r20Wd/Pbqv
-//        |P1s2+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry5
-//        |3mm+oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7Oyr
-//        |FAHqgDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUA
-//        |AN5WUtzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw
-//        |9lq4aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oy
-//        |c6XI2wIDAQABAoIBAQCUB8ip+kJiiZVKF8AqfB/aUP0jTAqOQewK1kKJ/iQCXBCq
-//        |pbo360gvdt05H5VZ/RDVkEgO2k73VSsbulqezKs8RFs2tEmU+JgTI9MeQJPWcP6X
-//        |aKy6LIYs0E2cWgp8GADgoBs8llBq0UhX0KffglIeek3n7Z6Gt4YFge2TAcW2WbN4
-//        |XfK7lupFyo6HHyWRiYHMMARQXLJeOSdTn5aMBP0PO4bQyk5ORxTUSeOciPJUFktQ
-//        |HkvGbym7KryEfwH8Tks0L7WhzyP60PL3xS9FNOJi9m+zztwYIXGDQuKM2GDsITeD
-//        |2mI2oHoPMyAD0wdI7BwSVW18p1h+jgfc4dlexKYRAoGBAOVfuiEiOchGghV5vn5N
-//        |RDNscAFnpHj1QgMr6/UG05RTgmcLfVsI1I4bSkbrIuVKviGGf7atlkROALOG/xRx
-//        |DLadgBEeNyHL5lz6ihQaFJLVQ0u3U4SB67J0YtVO3R6lXcIjBDHuY8SjYJ7Ci6Z6
-//        |vuDcoaEujnlrtUhaMxvSfcUJAoGBAMPsCHXte1uWNAqYad2WdLjPDlKtQJK1diCm
-//        |rqmB2g8QE99hDOHItjDBEdpyFBKOIP+NpVtM2KLhRajjcL9Ph8jrID6XUqikQuVi
-//        |4J9FV2m42jXMuioTT13idAILanYg8D3idvy/3isDVkON0X3UAVKrgMEne0hJpkPL
-//        |FYqgetvDAoGBAKLQ6JZMbSe0pPIJkSamQhsehgL5Rs51iX4m1z7+sYFAJfhvN3Q/
-//        |OGIHDRp6HjMUcxHpHw7U+S1TETxePwKLnLKj6hw8jnX2/nZRgWHzgVcY+sPsReRx
-//        |NJVf+Cfh6yOtznfX00p+JWOXdSY8glSSHJwRAMog+hFGW1AYdt7w80XBAoGBAImR
-//        |NUugqapgaEA8TrFxkJmngXYaAqpA0iYRA7kv3S4QavPBUGtFJHBNULzitydkNtVZ
-//        |3w6hgce0h9YThTo/nKc+OZDZbgfN9s7cQ75x0PQCAO4fx2P91Q+mDzDUVTeG30mE
-//        |t2m3S0dGe47JiJxifV9P3wNBNrZGSIF3mrORBVNDAoGBAI0QKn2Iv7Sgo4T/XjND
-//        |dl2kZTXqGAk8dOhpUiw/HdM3OGWbhHj2NdCzBliOmPyQtAr770GITWvbAI+IRYyF
-//        |S7Fnk6ZVVVHsxjtaHy1uJGFlaZzKR4AGNaUTOJMs6NadzCmGPAxNQQOCqoUjn4XR
-//        |rOjr9w349JooGXhOxbu8nOxX
-//        |-----END PRIVATE KEY-----""".stripMargin
-//
-//    override def privatePk8Key: PrivateKeyPEM =
-//      """-----BEGIN PRIVATE KEY-----
-//        |MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQCvi2abevbRZ389
-//        |uq8/Wzb5AS2+m5FpXxirjSCNRHzLZGPFrp2kbYZcds9+8yzxy34uHUYfjnHbxHDd
-//        |HLneab6gBePJDzo6cORnk3yVhuCAPg7fDozqkC8uSGT3kCd1OuJ9sgU81Tw88w7s
-//        |7KsUAeqAOzOeM8WZM60IRw3ZnUWlaByHC5gs8v5aiSqW13XWeqrOL5sn1y9IoANh
-//        |1QAA3lZS3N2mLLottOBLE/uhyJThOfSDkjpoNknsDwvOjQpLJligDjzmapw7QZUB
-//        |1XD2Wrho5P2/p36dvhuc2RBWSUtDd9UC8mb7F0M6n0sI0I3jxXamcM6QVXr5T2dX
-//        |mjJzpcjbAgMBAAECggEBAJQHyKn6QmKJlUoXwCp8H9pQ/SNMCo5B7ArWQon+JAJc
-//        |EKqlujfrSC923TkflVn9ENWQSA7aTvdVKxu6Wp7MqzxEWza0SZT4mBMj0x5Ak9Zw
-//        |/pdorLoshizQTZxaCnwYAOCgGzyWUGrRSFfQp9+CUh56Teftnoa3hgWB7ZMBxbZZ
-//        |s3hd8ruW6kXKjocfJZGJgcwwBFBcsl45J1OflowE/Q87htDKTk5HFNRJ45yI8lQW
-//        |S1AeS8ZvKbsqvIR/AfxOSzQvtaHPI/rQ8vfFL0U04mL2b7PO3BghcYNC4ozYYOwh
-//        |N4PaYjageg8zIAPTB0jsHBJVbXynWH6OB9zh2V7EphECgYEA5V+6ISI5yEaCFXm+
-//        |fk1EM2xwAWekePVCAyvr9QbTlFOCZwt9WwjUjhtKRusi5Uq+IYZ/tq2WRE4As4b/
-//        |FHEMtp2AER43IcvmXPqKFBoUktVDS7dThIHrsnRi1U7dHqVdwiMEMe5jxKNgnsKL
-//        |pnq+4NyhoS6OeWu1SFozG9J9xQkCgYEAw+wIde17W5Y0Cphp3ZZ0uM8OUq1AkrV2
-//        |IKauqYHaDxAT32EM4ci2MMER2nIUEo4g/42lW0zYouFFqONwv0+HyOsgPpdSqKRC
-//        |5WLgn0VXabjaNcy6KhNPXeJ0AgtqdiDwPeJ2/L/eKwNWQ43RfdQBUquAwSd7SEmm
-//        |Q8sViqB628MCgYEAotDolkxtJ7Sk8gmRJqZCGx6GAvlGznWJfibXPv6xgUAl+G83
-//        |dD84YgcNGnoeMxRzEekfDtT5LVMRPF4/AoucsqPqHDyOdfb+dlGBYfOBVxj6w+xF
-//        |5HE0lV/4J+HrI63Od9fTSn4lY5d1JjyCVJIcnBEAyiD6EUZbUBh23vDzRcECgYEA
-//        |iZE1S6CpqmBoQDxOsXGQmaeBdhoCqkDSJhEDuS/dLhBq88FQa0UkcE1QvOK3J2Q2
-//        |1VnfDqGBx7SH1hOFOj+cpz45kNluB832ztxDvnHQ9AIA7h/HY/3VD6YPMNRVN4bf
-//        |SYS3abdLR0Z7jsmInGJ9X0/fA0E2tkZIgXeas5EFU0MCgYEAjRAqfYi/tKCjhP9e
-//        |M0N2XaRlNeoYCTx06GlSLD8d0zc4ZZuEePY10LMGWI6Y/JC0CvvvQYhNa9sAj4hF
-//        |jIVLsWeTplVVUezGO1ofLW4kYWVpnMpHgAY1pRM4kyzo1p3MKYY8DE1BA4KqhSOf
-//        |hdGs6Ov3Dfj0migZeE7Fu7yc7Fc=
-//        |-----END PRIVATE KEY-----""".stripMargin
-//
-//    override def publicKey: PublicKeyPEM =
-//      """-----BEGIN PUBLIC KEY-----
-//        |MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4tmm3r20Wd/PbqvP1s2
-//        |+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry53mm+
-//        |oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7OyrFAHq
-//        |gDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUAAN5W
-//        |Utzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw9lq4
-//        |aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI
-//        |2wIDAQAB
-//        |-----END PUBLIC KEY-----"""".stripMargin
-//
-//    override def keyAlg: AsymmetricKeyAlg = AsymmetricKeyAlg.RSA_PSS_Key
-//  }
+//  val `test-key-rsa-pss` = HttpMessageSignaturesV07.`test-key-rsa-pss`
+  /**
+   * 2048-bit RSA public and private key pair taken from
+   * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.2 draft 13 Appendix B.1.2]]
+   */
+  object `test-key-rsa-pss` extends TestKeyPair {
+    override def description: String = "test-key-rsa-pss"
+
+    override def privateKey: PrivateKeyPEM =
+      """-----BEGIN PRIVATE KEY-----
+        |MIIEvgIBADALBgkqhkiG9w0BAQoEggSqMIIEpgIBAAKCAQEAr4tmm3r20Wd/Pbqv
+        |P1s2+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry5
+        |3mm+oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7Oyr
+        |FAHqgDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUA
+        |AN5WUtzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw
+        |9lq4aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oy
+        |c6XI2wIDAQABAoIBAQCUB8ip+kJiiZVKF8AqfB/aUP0jTAqOQewK1kKJ/iQCXBCq
+        |pbo360gvdt05H5VZ/RDVkEgO2k73VSsbulqezKs8RFs2tEmU+JgTI9MeQJPWcP6X
+        |aKy6LIYs0E2cWgp8GADgoBs8llBq0UhX0KffglIeek3n7Z6Gt4YFge2TAcW2WbN4
+        |XfK7lupFyo6HHyWRiYHMMARQXLJeOSdTn5aMBP0PO4bQyk5ORxTUSeOciPJUFktQ
+        |HkvGbym7KryEfwH8Tks0L7WhzyP60PL3xS9FNOJi9m+zztwYIXGDQuKM2GDsITeD
+        |2mI2oHoPMyAD0wdI7BwSVW18p1h+jgfc4dlexKYRAoGBAOVfuiEiOchGghV5vn5N
+        |RDNscAFnpHj1QgMr6/UG05RTgmcLfVsI1I4bSkbrIuVKviGGf7atlkROALOG/xRx
+        |DLadgBEeNyHL5lz6ihQaFJLVQ0u3U4SB67J0YtVO3R6lXcIjBDHuY8SjYJ7Ci6Z6
+        |vuDcoaEujnlrtUhaMxvSfcUJAoGBAMPsCHXte1uWNAqYad2WdLjPDlKtQJK1diCm
+        |rqmB2g8QE99hDOHItjDBEdpyFBKOIP+NpVtM2KLhRajjcL9Ph8jrID6XUqikQuVi
+        |4J9FV2m42jXMuioTT13idAILanYg8D3idvy/3isDVkON0X3UAVKrgMEne0hJpkPL
+        |FYqgetvDAoGBAKLQ6JZMbSe0pPIJkSamQhsehgL5Rs51iX4m1z7+sYFAJfhvN3Q/
+        |OGIHDRp6HjMUcxHpHw7U+S1TETxePwKLnLKj6hw8jnX2/nZRgWHzgVcY+sPsReRx
+        |NJVf+Cfh6yOtznfX00p+JWOXdSY8glSSHJwRAMog+hFGW1AYdt7w80XBAoGBAImR
+        |NUugqapgaEA8TrFxkJmngXYaAqpA0iYRA7kv3S4QavPBUGtFJHBNULzitydkNtVZ
+        |3w6hgce0h9YThTo/nKc+OZDZbgfN9s7cQ75x0PQCAO4fx2P91Q+mDzDUVTeG30mE
+        |t2m3S0dGe47JiJxifV9P3wNBNrZGSIF3mrORBVNDAoGBAI0QKn2Iv7Sgo4T/XjND
+        |dl2kZTXqGAk8dOhpUiw/HdM3OGWbhHj2NdCzBliOmPyQtAr770GITWvbAI+IRYyF
+        |S7Fnk6ZVVVHsxjtaHy1uJGFlaZzKR4AGNaUTOJMs6NadzCmGPAxNQQOCqoUjn4XR
+        |rOjr9w349JooGXhOxbu8nOxX
+        |-----END PRIVATE KEY-----""".stripMargin
+
+    override def privatePk8Key: PrivateKeyPEM =
+      HttpMessageSignaturesV07.`test-key-rsa-pss`.privatePk8Key
+
+    override def publicKey: PublicKeyPEM =
+      """-----BEGIN PUBLIC KEY-----
+        |MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4tmm3r20Wd/PbqvP1s2
+        |+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry53mm+
+        |oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7OyrFAHq
+        |gDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUAAN5W
+        |Utzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw9lq4
+        |aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI
+        |2wIDAQAB
+        |-----END PUBLIC KEY-----"""".stripMargin
+
+    override def keyAlg: AsymmetricKeyAlg = AsymmetricKeyAlg.RSA_PSS_Key
+  }
 
   /**
    * Taken from

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
@@ -16,7 +16,7 @@
 
 package bobcats
 
-import bobcats.SignatureExample.Base64Bytes
+import bobcats.SignatureExample.{Base64Bytes, PublicKeyPEM}
 import util.StringUtils.StringW
 
 /**
@@ -38,7 +38,10 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
     `§2.5_Example`,
     `Appendix_B.2.2`,
     `Appendix_B.2.3`,
-    `Appendix_B.2.4`
+    `Appendix_B.2.4`,
+    `Appendix_B.2.6`,
+    `Appendix_B.3`,
+    `Appendix_B.4`
   )
 
   object `§2.4_Example`
@@ -167,82 +170,145 @@ object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyE
         key = `test-shared-secret`,
         signatureAlg = HmacAlgorithm.SHA256)
 
+  object `Appendix_B.2.6`
+      extends SignatureExample(
+        description = "Abbpendix B.2.6 Signing a Request using ed25519",
+        sigtext = """\
+       |"date": Tue, 20 Apr 2021 02:07:55 GMT
+       |"@method": POST
+       |"@path": /foo
+       |"@authority": example.com
+       |"content-type": application/json
+       |"content-length": 18
+       |"@signature-params": ("date" "@method" "@path" "@authority" \
+       |  "content-type" "content-length");created=1618884473\
+       |  ;keyid="test-key-ed25519"""".rfc8792single,
+        signature = """wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1\
+         u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==""".rfc8792single,
+        keypair = `test-key-ed25519`,
+        signatureAlg = AsymmetricKeyAlg.`ed25119`,
+        valid = true)
+
+  object `Appendix_B.3`
+      extends SignatureExample(
+        description = "Appendix B.3: TLS-Terminating Example",
+        sigtext =
+          """\
+       |"@path": /foo
+       |"@query": ?param=Value&Pet=dog
+       |"@method": POST
+       |"@authority": service.internal.example
+       |"client-cert": :MIIBqDCCAU6gAwIBAgIBBzAKBggqhkjOPQQDAjA6MRswGQYDVQQ\
+       |  KDBJMZXQncyBBdXRoZW50aWNhdGUxGzAZBgNVBAMMEkxBIEludGVybWVkaWF0ZSBD\
+       |  QTAeFw0yMDAxMTQyMjU1MzNaFw0yMTAxMjMyMjU1MzNaMA0xCzAJBgNVBAMMAkJDM\
+       |  FkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8YnXXfaUgmnMtOXU/IncWalRhebrXm\
+       |  ckC8vdgJ1p5Be5F/3YC8OthxM4+k1M6aEAEFcGzkJiNy6J84y7uzo9M6NyMHAwCQY\
+       |  DVR0TBAIwADAfBgNVHSMEGDAWgBRm3WjLa38lbEYCuiCPct0ZaSED2DAOBgNVHQ8B\
+       |  Af8EBAMCBsAwEwYDVR0lBAwwCgYIKwYBBQUHAwIwHQYDVR0RAQH/BBMwEYEPYmRjQ\
+       |  GV4YW1wbGUuY29tMAoGCCqGSM49BAMCA0gAMEUCIBHda/r1vaL6G3VliL4/Di6YK0\
+       |  Q6bMjeSkC3dFCOOB8TAiEAx/kHSB4urmiZ0NX5r5XarmPk0wmuydBVoU4hBVZ1yhk=:
+       |"@signature-params": ("@path" "@query" "@method" "@authority" \
+       |  "client-cert");created=1618884473;keyid="test-key-ecc-p256"""".rfc8792single,
+        signature = """xVMHVpawaAC/0SbHrKRs9i8I3eOs5RtTMGCWXm/9nvZzoHsIg6Mce9315T6xoklyy0y\
+       zhD9ah4JHRwMLOgmizw==""".rfc8792single,
+        keypair = `test-key-ecc-p256`,
+        signatureAlg = AsymmetricKeyAlg.`ecdsa-p256-sha256`,
+        valid = true)
+
+  object `Appendix_B.4`
+      extends SignatureExample(
+        description = "Appendix B.4 Http Message Transforamation",
+        sigtext = """\
+            |"@method": GET
+            |"@path": /demo
+            |"@authority": example.org
+            |"accept": application/json, */*
+            |"@signature-params": ("@method" "@path" "@authority" "accept")\
+            |  ;created=1618884473;keyid="test-key-ed25519"""".rfc8792single,
+        signature = """ZT1kooQsEHpZ0I1IjCqtQppOmIqlJPeo7DHR3SoMn0s5J\
+         Z1eRGS0A+vyYP9t/LXlh5QMFFQ6cpLt2m0pmj3NDA==""".rfc8792single,
+        keypair = `test-key-ed25519`,
+        signatureAlg = AsymmetricKeyAlg.`ed25119`,
+        valid = true)
+
+  // thanks to sjrd for this tip
+  def isJS: Boolean = 1.0.toString() == "1"
+
   // 2048-bit RSA public and private key pair,
   // given in https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-07.html#appendix-B.1.1
   // this key did not change
   val `test-key-rsa` = HttpMessageSignaturesV07.`test-key-rsa`
 
-  val `test-key-rsa-pss` = HttpMessageSignaturesV07.`test-key-rsa-pss`
-
   /**
    * 2048-bit RSA public and private key pair taken from
    * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.2 draft 13 Appendix B.1.2]]
    */
-  /*
-  object `test-key-rsa-pss` extends TestKeyPair {
-    override def description: String = "test-key-rsa-pss"
+  def `test-key-rsa-pss` = if (isJS)
+    HttpMessageSignaturesV07.`test-key-rsa-pss`
+  else {
+    // these are the new keys, but they can't be loaded into Web Crypto API
+    // https://github.com/httpwg/http-extensions/issues/2290
+    new TestKeyPair {
+      override def description: String = "test-key-rsa-pss"
 
-    override def privateKey: PrivateKeyPEM =
-      """-----BEGIN PRIVATE KEY-----
-        |MIIEvgIBADALBgkqhkiG9w0BAQoEggSqMIIEpgIBAAKCAQEAr4tmm3r20Wd/Pbqv
-        |P1s2+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry5
-        |3mm+oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7Oyr
-        |FAHqgDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUA
-        |AN5WUtzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw
-        |9lq4aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oy
-        |c6XI2wIDAQABAoIBAQCUB8ip+kJiiZVKF8AqfB/aUP0jTAqOQewK1kKJ/iQCXBCq
-        |pbo360gvdt05H5VZ/RDVkEgO2k73VSsbulqezKs8RFs2tEmU+JgTI9MeQJPWcP6X
-        |aKy6LIYs0E2cWgp8GADgoBs8llBq0UhX0KffglIeek3n7Z6Gt4YFge2TAcW2WbN4
-        |XfK7lupFyo6HHyWRiYHMMARQXLJeOSdTn5aMBP0PO4bQyk5ORxTUSeOciPJUFktQ
-        |HkvGbym7KryEfwH8Tks0L7WhzyP60PL3xS9FNOJi9m+zztwYIXGDQuKM2GDsITeD
-        |2mI2oHoPMyAD0wdI7BwSVW18p1h+jgfc4dlexKYRAoGBAOVfuiEiOchGghV5vn5N
-        |RDNscAFnpHj1QgMr6/UG05RTgmcLfVsI1I4bSkbrIuVKviGGf7atlkROALOG/xRx
-        |DLadgBEeNyHL5lz6ihQaFJLVQ0u3U4SB67J0YtVO3R6lXcIjBDHuY8SjYJ7Ci6Z6
-        |vuDcoaEujnlrtUhaMxvSfcUJAoGBAMPsCHXte1uWNAqYad2WdLjPDlKtQJK1diCm
-        |rqmB2g8QE99hDOHItjDBEdpyFBKOIP+NpVtM2KLhRajjcL9Ph8jrID6XUqikQuVi
-        |4J9FV2m42jXMuioTT13idAILanYg8D3idvy/3isDVkON0X3UAVKrgMEne0hJpkPL
-        |FYqgetvDAoGBAKLQ6JZMbSe0pPIJkSamQhsehgL5Rs51iX4m1z7+sYFAJfhvN3Q/
-        |OGIHDRp6HjMUcxHpHw7U+S1TETxePwKLnLKj6hw8jnX2/nZRgWHzgVcY+sPsReRx
-        |NJVf+Cfh6yOtznfX00p+JWOXdSY8glSSHJwRAMog+hFGW1AYdt7w80XBAoGBAImR
-        |NUugqapgaEA8TrFxkJmngXYaAqpA0iYRA7kv3S4QavPBUGtFJHBNULzitydkNtVZ
-        |3w6hgce0h9YThTo/nKc+OZDZbgfN9s7cQ75x0PQCAO4fx2P91Q+mDzDUVTeG30mE
-        |t2m3S0dGe47JiJxifV9P3wNBNrZGSIF3mrORBVNDAoGBAI0QKn2Iv7Sgo4T/XjND
-        |dl2kZTXqGAk8dOhpUiw/HdM3OGWbhHj2NdCzBliOmPyQtAr770GITWvbAI+IRYyF
-        |S7Fnk6ZVVVHsxjtaHy1uJGFlaZzKR4AGNaUTOJMs6NadzCmGPAxNQQOCqoUjn4XR
-        |rOjr9w349JooGXhOxbu8nOxX
-        |-----END PRIVATE KEY-----""".stripMargin
+      override def privateKey: PrivateKeyPEM =
+        """-----BEGIN PRIVATE KEY-----
+          |MIIEvgIBADALBgkqhkiG9w0BAQoEggSqMIIEpgIBAAKCAQEAr4tmm3r20Wd/Pbqv
+          |P1s2+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry5
+          |3mm+oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7Oyr
+          |FAHqgDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUA
+          |AN5WUtzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw
+          |9lq4aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oy
+          |c6XI2wIDAQABAoIBAQCUB8ip+kJiiZVKF8AqfB/aUP0jTAqOQewK1kKJ/iQCXBCq
+          |pbo360gvdt05H5VZ/RDVkEgO2k73VSsbulqezKs8RFs2tEmU+JgTI9MeQJPWcP6X
+          |aKy6LIYs0E2cWgp8GADgoBs8llBq0UhX0KffglIeek3n7Z6Gt4YFge2TAcW2WbN4
+          |XfK7lupFyo6HHyWRiYHMMARQXLJeOSdTn5aMBP0PO4bQyk5ORxTUSeOciPJUFktQ
+          |HkvGbym7KryEfwH8Tks0L7WhzyP60PL3xS9FNOJi9m+zztwYIXGDQuKM2GDsITeD
+          |2mI2oHoPMyAD0wdI7BwSVW18p1h+jgfc4dlexKYRAoGBAOVfuiEiOchGghV5vn5N
+          |RDNscAFnpHj1QgMr6/UG05RTgmcLfVsI1I4bSkbrIuVKviGGf7atlkROALOG/xRx
+          |DLadgBEeNyHL5lz6ihQaFJLVQ0u3U4SB67J0YtVO3R6lXcIjBDHuY8SjYJ7Ci6Z6
+          |vuDcoaEujnlrtUhaMxvSfcUJAoGBAMPsCHXte1uWNAqYad2WdLjPDlKtQJK1diCm
+          |rqmB2g8QE99hDOHItjDBEdpyFBKOIP+NpVtM2KLhRajjcL9Ph8jrID6XUqikQuVi
+          |4J9FV2m42jXMuioTT13idAILanYg8D3idvy/3isDVkON0X3UAVKrgMEne0hJpkPL
+          |FYqgetvDAoGBAKLQ6JZMbSe0pPIJkSamQhsehgL5Rs51iX4m1z7+sYFAJfhvN3Q/
+          |OGIHDRp6HjMUcxHpHw7U+S1TETxePwKLnLKj6hw8jnX2/nZRgWHzgVcY+sPsReRx
+          |NJVf+Cfh6yOtznfX00p+JWOXdSY8glSSHJwRAMog+hFGW1AYdt7w80XBAoGBAImR
+          |NUugqapgaEA8TrFxkJmngXYaAqpA0iYRA7kv3S4QavPBUGtFJHBNULzitydkNtVZ
+          |3w6hgce0h9YThTo/nKc+OZDZbgfN9s7cQ75x0PQCAO4fx2P91Q+mDzDUVTeG30mE
+          |t2m3S0dGe47JiJxifV9P3wNBNrZGSIF3mrORBVNDAoGBAI0QKn2Iv7Sgo4T/XjND
+          |dl2kZTXqGAk8dOhpUiw/HdM3OGWbhHj2NdCzBliOmPyQtAr770GITWvbAI+IRYyF
+          |S7Fnk6ZVVVHsxjtaHy1uJGFlaZzKR4AGNaUTOJMs6NadzCmGPAxNQQOCqoUjn4XR
+          |rOjr9w349JooGXhOxbu8nOxX
+          |-----END PRIVATE KEY-----""".stripMargin
 
-    override def privatePk8Key: PrivateKeyPEM =
-      HttpMessageSignaturesV07.`test-key-rsa-pss`.privatePk8Key
+      override def publicKey: PublicKeyPEM =
+        """-----BEGIN PUBLIC KEY-----
+          |MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4tmm3r20Wd/PbqvP1s2
+          |+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry53mm+
+          |oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7OyrFAHq
+          |gDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUAAN5W
+          |Utzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw9lq4
+          |aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI
+          |2wIDAQAB
+          |-----END PUBLIC KEY-----"""".stripMargin
 
-    override def publicKey: PublicKeyPEM =
-      """-----BEGIN PUBLIC KEY-----
-        |MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr4tmm3r20Wd/PbqvP1s2
-        |+QEtvpuRaV8Yq40gjUR8y2Rjxa6dpG2GXHbPfvMs8ct+Lh1GH45x28Rw3Ry53mm+
-        |oAXjyQ86OnDkZ5N8lYbggD4O3w6M6pAvLkhk95AndTrifbIFPNU8PPMO7OyrFAHq
-        |gDsznjPFmTOtCEcN2Z1FpWgchwuYLPL+Wokqltd11nqqzi+bJ9cvSKADYdUAAN5W
-        |Utzdpiy6LbTgSxP7ociU4Tn0g5I6aDZJ7A8Lzo0KSyZYoA485mqcO0GVAdVw9lq4
-        |aOT9v6d+nb4bnNkQVklLQ3fVAvJm+xdDOp9LCNCN48V2pnDOkFV6+U9nV5oyc6XI
-        |2wIDAQAB
-        |-----END PUBLIC KEY-----"""".stripMargin
-
-    override def keyAlg: AsymmetricKeyAlg = AsymmetricKeyAlg.RSA_PSS_Key
+      override def keyAlg: AsymmetricKeyAlg = AsymmetricKeyAlg.RSA_PSS_Key
+    }
   }
-   */
 
   /**
    * Taken from
    * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.3 draft 13 Appendix B.1.3]]
    * This did not change from draft 7
    */
-  val `test-key-ecc-p256` = HttpMessageSignaturesV07.`test-key-ecc-p256`
+  val `test-key-ecc-p256`: TestKeyPair = HttpMessageSignaturesV07.`test-key-ecc-p256`
 
   /**
    * Taken from
    * [[https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#appendix-B.1.3 draft 13 Appendix B.1.4]]
    * This did not change from draft 7
    */
-  val `test-key-ed25519` = HttpMessageSignaturesV07.`test-key-ed25519`
+  val `test-key-ed25519`: TestKeyPair = HttpMessageSignaturesV07.`test-key-ed25519`
 
   /**
    * Symmetric key from Appendix B.1.5

--- a/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
+++ b/core/shared/src/test/scala/bobcats/HttpMessageSignaturesV13.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package bobcats
 
 import bobcats.SignatureExample.Base64Bytes
@@ -11,7 +27,7 @@ import util.StringUtils.StringW
  */
 object HttpMessageSignaturesV13 extends AsymmetricKeyExamples with SymmetricKeyExamples {
 
-  import SignatureExample.{PrivateKeyPEM, PublicKeyPEM}
+  import SignatureExample.PrivateKeyPEM
 
   override def symSignExamples: Seq[SymmetricSignatureExample] = Seq(
     `Appendix_B.2.5`

--- a/core/shared/src/test/scala/bobcats/SignatureExample.scala
+++ b/core/shared/src/test/scala/bobcats/SignatureExample.scala
@@ -33,11 +33,12 @@ sealed trait SigExample
  * Collects a number of signatures for a given Key
  */
 case class SignatureExample(
-    description: String,
-    sigtext: SigningString,
-    signature: Signature,
-    keypair: TestKeyPair,
-    signatureAlg: AsymmetricKeyAlg.Signature
+    description: String, // description of the example
+    sigtext: SigningString, // the text to be signed
+    signature: Signature, // the expected sigature
+    keypair: TestKeyPair, // the key pair that can sign and verify the
+    signatureAlg: AsymmetricKeyAlg.Signature,
+    valid: Boolean = true
 ) extends SigExample
 
 case class SymmetricSignatureExample(
@@ -45,7 +46,8 @@ case class SymmetricSignatureExample(
     sigtext: SigningString,
     signature: Signature,
     key: TestSharedKey,
-    signatureAlg: HmacAlgorithm
+    signatureAlg: HmacAlgorithm,
+    valid: Boolean = true
 ) extends SigExample
 
 trait AsymmetricKeyExamples {

--- a/core/shared/src/test/scala/bobcats/SignatureExample.scala
+++ b/core/shared/src/test/scala/bobcats/SignatureExample.scala
@@ -39,7 +39,9 @@ case class SignatureExample(
     keypair: TestKeyPair, // the key pair that can sign and verify the
     signatureAlg: AsymmetricKeyAlg.Signature,
     valid: Boolean = true
-) extends SigExample
+) extends SigExample {
+  def notFor(): Set[NotFor] = keypair.limitation
+}
 
 case class SymmetricSignatureExample(
     description: String,
@@ -63,6 +65,9 @@ trait SymmetricKeyExamples {
 sealed trait TestKey {
   def description: String
 }
+
+sealed trait NotFor
+case class NoWebCryptAPI(msg: String, doc: List[java.net.URI]) extends NotFor
 
 /**
  * Public and Private keys grouped together as in
@@ -98,6 +103,12 @@ trait TestKeyPair extends TestKey {
   def publicPk8Key: PublicKeyPEM = publicKey
 
   def keyAlg: AsymmetricKeyAlg
+
+  /**
+   * platform limitation descriptions that can be used to filter out tests and also provide some
+   * readalbe documentation
+   */
+  def limitation: Set[NotFor] = Set()
 }
 
 trait TestSharedKey extends TestKey {

--- a/core/shared/src/test/scala/bobcats/SignatureExample.scala
+++ b/core/shared/src/test/scala/bobcats/SignatureExample.scala
@@ -78,9 +78,13 @@ trait TestKeyPair extends TestKey {
   // but then it would not be easy to compare the keys used here with those in the
   // spec when debugging the tests, and it would make it more difficult to send in
   // feedback to the IETF HttpBis WG.
+  /** here we put the key from the spec */
   def privateKey: PrivateKeyPEM
 
   // PKCS8 version of the private key
+  // there have been problems with keys in JS explained
+  // https://github.com/httpwg/http-extensions/issues/1867
+  /** place the pkcs8 equivalent key here  */
   def privatePk8Key: PrivateKeyPEM = privateKey
 
   def publicKey: PublicKeyPEM

--- a/core/shared/src/test/scala/bobcats/SignatureExample.scala
+++ b/core/shared/src/test/scala/bobcats/SignatureExample.scala
@@ -20,7 +20,7 @@ object SignatureExample {
   type SigningString = String
   type Signature = String
   type Base64Bytes = String
-  
+
   type PrivateKeyPEM = String
   type PublicKeyPEM = String
 }
@@ -41,11 +41,11 @@ case class SignatureExample(
 ) extends SigExample
 
 case class SymmetricSignatureExample(
-  description: String,
-  sigtext: SigningString,
-  signature: Signature,
-  key: TestSharedKey,
-  signatureAlg: HmacAlgorithm
+    description: String,
+    sigtext: SigningString,
+    signature: Signature,
+    key: TestSharedKey,
+    signatureAlg: HmacAlgorithm
 ) extends SigExample
 
 trait AsymmetricKeyExamples {
@@ -70,7 +70,7 @@ sealed trait TestKey {
  */
 trait TestKeyPair extends TestKey {
   import SignatureExample.{PrivateKeyPEM, PublicKeyPEM}
-  
+
   // the keys in the Signing HTTP messages Spec are PEM encoded.
   // One could transform the keys from PKCS#1 to PKCS#8 using
   // openssl pkcs8 -topk8 -inform PEM -in spec.private.pem -out private.pem -nocrypt
@@ -78,13 +78,17 @@ trait TestKeyPair extends TestKey {
   // but then it would not be easy to compare the keys used here with those in the
   // spec when debugging the tests, and it would make it more difficult to send in
   // feedback to the IETF HttpBis WG.
-  /** here we put the key from the spec */
+  /**
+   * here we put the key from the spec
+   */
   def privateKey: PrivateKeyPEM
 
   // PKCS8 version of the private key
   // there have been problems with keys in JS explained
   // https://github.com/httpwg/http-extensions/issues/1867
-  /** place the pkcs8 equivalent key here  */
+  /**
+   * place the pkcs8 equivalent key here
+   */
   def privatePk8Key: PrivateKeyPEM = privateKey
 
   def publicKey: PublicKeyPEM
@@ -95,5 +99,5 @@ trait TestKeyPair extends TestKey {
 }
 
 trait TestSharedKey extends TestKey {
-   def sharedKey: Base64Bytes
+  def sharedKey: Base64Bytes
 }

--- a/core/shared/src/test/scala/bobcats/SignerSuite.scala
+++ b/core/shared/src/test/scala/bobcats/SignerSuite.scala
@@ -39,7 +39,7 @@ trait SignerSuite extends CatsEffectSuite {
     import cats.implicits._
     (Random[F].nextAlphaNumeric, Random[F].betweenInt(0, signingStr.length)).mapN { (c, ri) =>
       // we make our life easy, since we can make the string longer
-      if (ri == 0 || signingStr.charAt(ri) == c) { signingStr.appended(c) }
+      if (ri == 0 || signingStr.charAt(ri) == c) { signingStr + c }
       else {
         val (a, b) = signingStr.splitAt(ri)
         a + c + b.tail

--- a/core/shared/src/test/scala/bobcats/SignerSuite.scala
+++ b/core/shared/src/test/scala/bobcats/SignerSuite.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
 import scala.util.Try
 
 /*
- * todo: does one need CatsEffectSuite?  (We don't use assertIO, ...)
+ * Suite for testing signatures.
  */
 trait SignerSuite extends CatsEffectSuite {
   type MonadErr[T[_]] = MonadError[T, Throwable]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.7.3


### PR DESCRIPTION
[Draft 13 of HTTP Message Signatures](
https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures-13#appendix-B.2.3) is in last call. Updating the examples here, allows me then to update the code in https://github.com/bblfish/httpSig